### PR TITLE
Part2-4~7. 상품 리포지토리 구현 실습

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,16 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>com.querydsl</groupId>
+			<artifactId>querydsl-jpa</artifactId>
+			<version>5.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.querydsl</groupId>
+			<artifactId>querydsl-apt</artifactId>
+			<version>5.0.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -65,6 +75,22 @@
 						</exclude>
 					</excludes>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>com.mysema.maven</groupId>
+				<artifactId>apt-maven-plugin</artifactId>
+				<version>1.1.3</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>process</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>target/generated-sources/java</outputDirectory>
+							<processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/catveloper365/studyshop/repository/ItemRepository.java
+++ b/src/main/java/com/catveloper365/studyshop/repository/ItemRepository.java
@@ -1,0 +1,7 @@
+package com.catveloper365.studyshop.repository;
+
+import com.catveloper365.studyshop.entity.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+}

--- a/src/main/java/com/catveloper365/studyshop/repository/ItemRepository.java
+++ b/src/main/java/com/catveloper365/studyshop/repository/ItemRepository.java
@@ -3,5 +3,12 @@ package com.catveloper365.studyshop.repository;
 import com.catveloper365.studyshop.entity.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ItemRepository extends JpaRepository<Item, Long> {
+
+    List<Item> findByItemNm(String itemNm); //상품명으로 조회
+
+    //상품명 혹은 상품 상세 설명으로 조회
+    List<Item> findByItemNmOrItemDetail(String itemNm, String itemDetail);
 }

--- a/src/main/java/com/catveloper365/studyshop/repository/ItemRepository.java
+++ b/src/main/java/com/catveloper365/studyshop/repository/ItemRepository.java
@@ -2,6 +2,8 @@ package com.catveloper365.studyshop.repository;
 
 import com.catveloper365.studyshop.entity.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -12,9 +14,25 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     //상품명 혹은 상품 상세 설명으로 조회
     List<Item> findByItemNmOrItemDetail(String itemNm, String itemDetail);
 
-    //파라미터 값보다 가격이 작은 상품 조회(오름차순)
+    //파라미터 값보다 가격이 작은 상품 조회(가격 오름차순)
     List<Item> findByPriceLessThan(Integer price);
 
-    //파라미터 값보다 가격이 작은 상품 조회(내림차순)
+    //파라미터 값보다 가격이 작은 상품 조회(가격 내림차순)
     List<Item> findByPriceLessThanOrderByPriceDesc(Integer price);
+
+    //검색어를 상품 상세 설명에 포함하고 있는 상품 & 가격 내림차순 조회
+    //파라미터 맵핑 방법으로 @Param 어노테이션 사용
+    @Query("select i from Item i where i.itemDetail like " +
+            "%:itemDetail% order by i.price desc")
+    List<Item> findByItemDetailByParam(@Param("itemDetail") String itemDetail);
+
+
+    //파라미터 맵핑 방법으로 ?파라미터 번호를 사용
+    @Query("select i from Item i where i.itemDetail like " +
+            "%?1% order by i.price desc")
+    List<Item> findByItemDetailByOrder(String itemDetail);
+
+    @Query(value="select * from item i where i.item_detail like " +
+            "%:itemDetail% order by i.price desc", nativeQuery = true)
+    List<Item> findByItemDetailByNative(@Param("itemDetail") String itemDetail);
 }

--- a/src/main/java/com/catveloper365/studyshop/repository/ItemRepository.java
+++ b/src/main/java/com/catveloper365/studyshop/repository/ItemRepository.java
@@ -3,11 +3,13 @@ package com.catveloper365.studyshop.repository;
 import com.catveloper365.studyshop.entity.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface ItemRepository extends JpaRepository<Item, Long> {
+public interface ItemRepository extends JpaRepository<Item, Long>,
+        QuerydslPredicateExecutor<Item> {
 
     List<Item> findByItemNm(String itemNm); //상품명으로 조회
 

--- a/src/main/java/com/catveloper365/studyshop/repository/ItemRepository.java
+++ b/src/main/java/com/catveloper365/studyshop/repository/ItemRepository.java
@@ -11,4 +11,10 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 
     //상품명 혹은 상품 상세 설명으로 조회
     List<Item> findByItemNmOrItemDetail(String itemNm, String itemDetail);
+
+    //파라미터 값보다 가격이 작은 상품 조회(오름차순)
+    List<Item> findByPriceLessThan(Integer price);
+
+    //파라미터 값보다 가격이 작은 상품 조회(내림차순)
+    List<Item> findByPriceLessThanOrderByPriceDesc(Integer price);
 }

--- a/src/test/java/com/catveloper365/studyshop/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/catveloper365/studyshop/repository/ItemRepositoryTest.java
@@ -202,5 +202,54 @@ class ItemRepositoryTest {
         assertThat(itemList.get(0).getPrice()).isEqualTo(10004);
     }
 
+    @Test
+    @DisplayName("@Query, JPQL, @Param을 사용한 상품 조회")
+    void findByItemDetailByParam() throws Exception {
+        //given
+        this.createItemList();
 
+        //when
+        List<Item> itemList = itemRepository.findByItemDetailByParam("테스트");
+
+        //then
+        for (Item item : itemList) {
+            System.out.println("item = " + item);
+        }
+        assertThat(itemList.size()).isEqualTo(10);
+        assertThat(itemList.get(0).getPrice()).isEqualTo(10010);
+    }
+
+    @Test
+    @DisplayName("@Query, JPQL, ?파라미터 번호를 사용한 상품 조회")
+    void findByItemDetailByOrder() throws Exception {
+        //given
+        this.createItemList();
+
+        //when
+        List<Item> itemList = itemRepository.findByItemDetailByOrder("테스트");
+
+        //then
+        for (Item item : itemList) {
+            System.out.println("item = " + item);
+        }
+        assertThat(itemList.size()).isEqualTo(10);
+        assertThat(itemList.get(0).getPrice()).isEqualTo(10010);
+    }
+
+    @Test
+    @DisplayName("@Query, nativeQuery, @Param을 사용한 상품 조회")
+    void findByItemDetailByNative() throws Exception {
+        //given
+        this.createItemList();
+
+        //when
+        List<Item> itemList = itemRepository.findByItemDetailByNative("테스트");
+
+        //then
+        for (Item item : itemList) {
+            System.out.println("item = " + item);
+        }
+        assertThat(itemList.size()).isEqualTo(10);
+        assertThat(itemList.get(0).getPrice()).isEqualTo(10010);
+    }
 }

--- a/src/test/java/com/catveloper365/studyshop/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/catveloper365/studyshop/repository/ItemRepositoryTest.java
@@ -2,7 +2,6 @@ package com.catveloper365.studyshop.repository;
 
 import com.catveloper365.studyshop.constant.ItemSellStatus;
 import com.catveloper365.studyshop.entity.Item;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +14,6 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
@@ -26,10 +24,12 @@ class ItemRepositoryTest {
     @PersistenceContext
     EntityManager em;
 
-    @Test
-    @DisplayName("저장 테스트")
-    public void save() {
-        //given
+    /**
+     * 테스트 데이터 생성
+     *
+     * @return Item
+     */
+    private Item createItem() {
         Item item = new Item();
         item.setItemNm("테스트 상품");
         item.setPrice(10000);
@@ -39,6 +39,14 @@ class ItemRepositoryTest {
         item.setRegTime(LocalDateTime.now());
         item.setUpdateTime(LocalDateTime.now());
         System.out.println(item);
+        return item;
+    }
+
+    @Test
+    @DisplayName("저장 테스트")
+    public void save() {
+        //given
+        Item item = createItem();
 
         //when
         itemRepository.save(item);
@@ -50,5 +58,43 @@ class ItemRepositoryTest {
         Optional<Item> findItem = itemRepository.findById(item.getId());
         assertThat(item.getItemNm()).isEqualTo(findItem.orElse(null).getItemNm());
         assertThat(item.getStockNumber()).isEqualTo(findItem.orElse(null).getStockNumber());
+    }
+
+    @Test
+    @DisplayName("삭제 테스트")
+    void delete() {
+        //given
+        Item item = createItem();
+        itemRepository.save(item);
+        long saveCnt = itemRepository.count();
+        assertThat(saveCnt).isEqualTo(1);
+
+        //when
+        itemRepository.delete(item);
+
+        //then
+        long removeCnt = itemRepository.count();
+        assertThat(removeCnt).isEqualTo(0);
+        Optional<Item> findItem = itemRepository.findById(item.getId());
+        assertThat(findItem).isEmpty();
+    }
+
+    @Test
+    @DisplayName("수정 테스트")
+    void update() {
+        //given
+        Item item = createItem();
+        Item savedItem = itemRepository.save(item);
+
+        //when
+        savedItem.setPrice(15000);
+        savedItem.setItemSellStatus(ItemSellStatus.SOLD_OUT);
+        em.flush();
+        em.clear();
+
+        //then
+        Optional<Item> findItem = itemRepository.findById(savedItem.getId());
+        assertThat(savedItem.getPrice()).isEqualTo(findItem.orElse(null).getPrice());
+        assertThat(savedItem.getItemSellStatus()).isEqualTo(findItem.orElse(null).getItemSellStatus());
     }
 }

--- a/src/test/java/com/catveloper365/studyshop/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/catveloper365/studyshop/repository/ItemRepositoryTest.java
@@ -56,8 +56,8 @@ class ItemRepositoryTest {
         em.clear(); //DB에서 조회해오도록 영속성 컨텍스트 비워주기
 
         Optional<Item> findItem = itemRepository.findById(item.getId());
-        assertThat(item.getItemNm()).isEqualTo(findItem.orElse(null).getItemNm());
-        assertThat(item.getStockNumber()).isEqualTo(findItem.orElse(null).getStockNumber());
+        assertThat(item.getItemNm()).isEqualTo(findItem.orElseGet(Item::new).getItemNm());
+        assertThat(item.getStockNumber()).isEqualTo(findItem.orElseGet(Item::new).getStockNumber());
     }
 
     @Test
@@ -77,6 +77,8 @@ class ItemRepositoryTest {
         assertThat(removeCnt).isEqualTo(0);
         Optional<Item> findItem = itemRepository.findById(item.getId());
         assertThat(findItem).isEmpty();
+        assertThat(findItem.orElseGet(Item::new).getItemNm()).isEqualTo(null);
+        assertThat(findItem.orElseGet(Item::new).getPrice()).isEqualTo(0);
     }
 
     @Test
@@ -94,7 +96,7 @@ class ItemRepositoryTest {
 
         //then
         Optional<Item> findItem = itemRepository.findById(savedItem.getId());
-        assertThat(savedItem.getPrice()).isEqualTo(findItem.orElse(null).getPrice());
-        assertThat(savedItem.getItemSellStatus()).isEqualTo(findItem.orElse(null).getItemSellStatus());
+        assertThat(savedItem.getPrice()).isEqualTo(findItem.orElseGet(Item::new).getPrice());
+        assertThat(savedItem.getItemSellStatus()).isEqualTo(findItem.orElseGet(Item::new).getItemSellStatus());
     }
 }

--- a/src/test/java/com/catveloper365/studyshop/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/catveloper365/studyshop/repository/ItemRepositoryTest.java
@@ -11,6 +11,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.transaction.Transactional;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,24 +27,34 @@ class ItemRepositoryTest {
 
     /**
      * 테스트 데이터 생성
-     *
-     * @return Item
      */
     private Item createItem() {
+        Item item = createItem("테스트 상품", 10000, "테스트 상품 상세 설명");
+        return item;
+    }
+
+    private Item createItem(String itemNm, int price, String itemDetail) {
         Item item = new Item();
-        item.setItemNm("테스트 상품");
-        item.setPrice(10000);
-        item.setItemDetail("테스트 상품 상세 설명");
+        item.setItemNm(itemNm);
+        item.setPrice(price);
+        item.setItemDetail(itemDetail);
         item.setItemSellStatus(ItemSellStatus.SELL);
         item.setStockNumber(100);
         item.setRegTime(LocalDateTime.now());
         item.setUpdateTime(LocalDateTime.now());
-        System.out.println(item);
+//        System.out.println(item);
         return item;
     }
 
+    private void createItemList() {
+        for (int i = 1; i <= 10; i++) {
+            Item item = createItem(("테스트 상품" + i), (10000 + i), ("테스트 상품 상세 설명" + i));
+            itemRepository.save(item);
+        }
+    }
+
     @Test
-    @DisplayName("저장 테스트")
+    @DisplayName("저장")
     public void save() {
         //given
         Item item = createItem();
@@ -61,7 +72,7 @@ class ItemRepositoryTest {
     }
 
     @Test
-    @DisplayName("삭제 테스트")
+    @DisplayName("삭제")
     void delete() {
         //given
         Item item = createItem();
@@ -82,7 +93,7 @@ class ItemRepositoryTest {
     }
 
     @Test
-    @DisplayName("수정 테스트")
+    @DisplayName("수정")
     void update() {
         //given
         Item item = createItem();
@@ -99,4 +110,62 @@ class ItemRepositoryTest {
         assertThat(savedItem.getPrice()).isEqualTo(findItem.orElseGet(Item::new).getPrice());
         assertThat(savedItem.getItemSellStatus()).isEqualTo(findItem.orElseGet(Item::new).getItemSellStatus());
     }
+
+    @Test
+    @DisplayName("상품명 조회")
+    void findByItemNmTest() {
+        //given
+        this.createItemList();
+
+        //when
+        String findItemNm = "테스트 상품5";
+        List<Item> itemList = itemRepository.findByItemNm(findItemNm);
+
+        //then
+//        for (Item item : itemList) {
+//            System.out.println("상품명 조회 결과 = " + item);
+//        }
+        assertThat(itemList.size()).isEqualTo(1);
+        assertThat(findItemNm).isEqualTo(itemList.get(0).getItemNm());
+    }
+
+    @Test
+    @DisplayName("상품명, 상품 상세 설명 모두 존재")
+    public void findNmOrDetailBoth() throws Exception {
+        //given
+        this.createItemList();
+
+        //when
+        String findItemNm = "테스트 상품10"; //DB에 있는 데이터
+        String findItemDetail = "테스트 상품 상세 설명5"; //DB에 있는 데이터
+        List<Item> itemList = itemRepository.findByItemNmOrItemDetail(findItemNm, findItemDetail);
+
+        //then
+//        for (Item item : itemList) {
+//            System.out.println("item = " + item);
+//        }
+        assertThat(itemList.size()).isEqualTo(2);
+        assertThat(findItemNm).isIn(itemList.get(0).getItemNm(), itemList.get(1).getItemNm());
+    }
+
+    @Test
+    @DisplayName("상품명, 상품 상세 설명 중 1개만 존재")
+    void findNmOrDetailOne() throws Exception {
+        //given
+        this.createItemList();
+
+        //when
+        String findItemNm = "테스트 상품"; //DB에 없는 데이터
+        String findItemDetail = "테스트 상품 상세 설명1"; //DB에 있는 데이터
+        List<Item> itemList = itemRepository.findByItemNmOrItemDetail(findItemNm, findItemDetail);
+
+        //then
+//        for (Item item : itemList) {
+//            System.out.println("item = " + item);
+//        }
+        assertThat(itemList.size()).isEqualTo(1);
+        assertThat(findItemDetail).isEqualTo(itemList.get(0).getItemDetail());
+    }
+
+
 }

--- a/src/test/java/com/catveloper365/studyshop/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/catveloper365/studyshop/repository/ItemRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.catveloper365.studyshop.repository;
+
+import com.catveloper365.studyshop.constant.ItemSellStatus;
+import com.catveloper365.studyshop.entity.Item;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class ItemRepositoryTest {
+    @Autowired
+    ItemRepository itemRepository;
+
+    @PersistenceContext
+    EntityManager em;
+
+    @Test
+    @DisplayName("저장 테스트")
+    public void save() {
+        //given
+        Item item = new Item();
+        item.setItemNm("테스트 상품");
+        item.setPrice(10000);
+        item.setItemDetail("테스트 상품 상세 설명");
+        item.setItemSellStatus(ItemSellStatus.SELL);
+        item.setStockNumber(100);
+        item.setRegTime(LocalDateTime.now());
+        item.setUpdateTime(LocalDateTime.now());
+        System.out.println(item);
+
+        //when
+        itemRepository.save(item);
+
+        //then
+        em.flush();
+        em.clear(); //DB에서 조회해오도록 영속성 컨텍스트 비워주기
+
+        Optional<Item> findItem = itemRepository.findById(item.getId());
+        assertThat(item.getItemNm()).isEqualTo(findItem.orElse(null).getItemNm());
+        assertThat(item.getStockNumber()).isEqualTo(findItem.orElse(null).getStockNumber());
+    }
+}

--- a/src/test/java/com/catveloper365/studyshop/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/catveloper365/studyshop/repository/ItemRepositoryTest.java
@@ -2,10 +2,18 @@ package com.catveloper365.studyshop.repository;
 
 import com.catveloper365.studyshop.constant.ItemSellStatus;
 import com.catveloper365.studyshop.entity.Item;
+import com.catveloper365.studyshop.entity.QItem;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.thymeleaf.util.StringUtils;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -29,17 +37,20 @@ class ItemRepositoryTest {
      * 테스트 데이터 생성
      */
     private Item createItem() {
-        Item item = createItem("테스트 상품", 10000, "테스트 상품 상세 설명");
+        Item item = createItem("테스트 상품", 10000, "테스트 상품 상세 설명", ItemSellStatus.SELL);
         return item;
     }
 
-    private Item createItem(String itemNm, int price, String itemDetail) {
+    private Item createItem(String itemNm, int price, String itemDetail, ItemSellStatus itemSellStatus) {
         Item item = new Item();
         item.setItemNm(itemNm);
         item.setPrice(price);
         item.setItemDetail(itemDetail);
-        item.setItemSellStatus(ItemSellStatus.SELL);
+        item.setItemSellStatus(itemSellStatus);
         item.setStockNumber(100);
+        if(itemSellStatus.equals(ItemSellStatus.SOLD_OUT)){
+            item.setStockNumber(0);
+        }
         item.setRegTime(LocalDateTime.now());
         item.setUpdateTime(LocalDateTime.now());
 //        System.out.println(item);
@@ -48,7 +59,18 @@ class ItemRepositoryTest {
 
     private void createItemList() {
         for (int i = 1; i <= 10; i++) {
-            Item item = createItem(("테스트 상품" + i), (10000 + i), ("테스트 상품 상세 설명" + i));
+            Item item = createItem(("테스트 상품" + i), (10000 + i), ("테스트 상품 상세 설명" + i), ItemSellStatus.SELL);
+            itemRepository.save(item);
+        }
+    }
+
+    private void createItemList2() {
+        for (int i = 1; i <= 5; i++) {
+            Item item = createItem("테스트 상품" + i, 10000 + i, "테스트 상품 상세 설명" + i, ItemSellStatus.SELL);
+            itemRepository.save(item);
+        }
+        for (int i = 6; i <= 10; i++) {
+            Item item = createItem("테스트 상품" + i, 10000 + i, "테스트 상품 상세 설명" + i, ItemSellStatus.SOLD_OUT);
             itemRepository.save(item);
         }
     }
@@ -203,7 +225,7 @@ class ItemRepositoryTest {
     }
 
     @Test
-    @DisplayName("@Query, JPQL, @Param을 사용한 상품 조회")
+    @DisplayName("@Query, JPQL, @Param 사용 상품 조회")
     void findByItemDetailByParam() throws Exception {
         //given
         this.createItemList();
@@ -220,7 +242,7 @@ class ItemRepositoryTest {
     }
 
     @Test
-    @DisplayName("@Query, JPQL, ?파라미터 번호를 사용한 상품 조회")
+    @DisplayName("@Query, JPQL, ?파라미터 번호 사용 상품 조회")
     void findByItemDetailByOrder() throws Exception {
         //given
         this.createItemList();
@@ -237,7 +259,7 @@ class ItemRepositoryTest {
     }
 
     @Test
-    @DisplayName("@Query, nativeQuery, @Param을 사용한 상품 조회")
+    @DisplayName("@Query, nativeQuery, @Param 사용 상품 조회")
     void findByItemDetailByNative() throws Exception {
         //given
         this.createItemList();
@@ -251,5 +273,74 @@ class ItemRepositoryTest {
         }
         assertThat(itemList.size()).isEqualTo(10);
         assertThat(itemList.get(0).getPrice()).isEqualTo(10010);
+    }
+
+    @Test
+    @DisplayName("Querydsl, JPAQueryFactory 사용 상품 조회")
+    void querydslByJPAQueryFactory() throws Exception {
+        //given
+        this.createItemList();
+
+        JPAQueryFactory queryFactory = new JPAQueryFactory(em);
+        QItem qItem = QItem.item;
+
+        //when
+        JPAQuery<Item> query = queryFactory.selectFrom(qItem)
+                .where(qItem.itemSellStatus.eq(ItemSellStatus.SELL))
+                .where(qItem.itemDetail.like("%" + "테스트" + "%"))
+                .orderBy(qItem.price.desc());
+
+//        List<Item> itemList = query.fetch(); //조회 결과 전체
+        Item findItem = query.fetchFirst(); //조회 결과 중 1건만
+
+        //then
+//        for (Item item : itemList) {
+//            System.out.println("item = " + item);
+//        }
+//        assertThat(itemList.size()).isEqualTo(10);
+//        assertThat(itemList.get(0).getPrice()).isEqualTo(10010);
+
+        System.out.println("findItem = " + findItem);
+        assertThat(findItem.getPrice()).isEqualTo(10010);
+    }
+
+    @Test
+    @DisplayName("Querydsl, QuerydslPredicateExecutor 사용 상품 조회")
+    void querydslByPredicateExecutor() throws Exception {
+        //given
+        this.createItemList2();
+
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+        QItem item = QItem.item;
+
+        //검색 조건
+        String itemDetail = "테스트";
+        int price = 10003;
+        String itemSellStatus = "SELL";
+
+        //when
+        booleanBuilder.and(item.itemDetail.like("%" + itemDetail + "%"));
+        booleanBuilder.and(item.price.gt(price)); //gt는 보다 큰 값만 검색(> 조건)
+
+        //조회 조건 동적 할당(판매 상태 검색 조건이 SELL인 경우에만 조건 사용)
+        if (StringUtils.equals(itemSellStatus, ItemSellStatus.SELL)) {
+            booleanBuilder.and(item.itemSellStatus.eq(ItemSellStatus.SELL));
+        }
+
+        //페이징하여 조회(조회할 페이지 번호, 한 페이지당 조회할 데이터 갯수)
+        Pageable pageable = PageRequest.of(0, 5);
+        //QuerydslPredicateExecutor 인터페이스에 정의된 findAll 사용
+        Page<Item> itemPagingResult = itemRepository.findAll(booleanBuilder, pageable);
+
+        //then
+        System.out.println("itemPagingResult.getTotalElements() = " + itemPagingResult.getTotalElements());
+
+        List<Item> resultItemList = itemPagingResult.getContent();
+        for (Item resultItem : resultItemList) {
+            System.out.println("resultItem = " + resultItem);
+        }
+
+        assertThat(itemPagingResult.getTotalElements()).isEqualTo(2);
+        assertThat(resultItemList.get(0).getPrice()).isIn(10004, 10005);
     }
 }

--- a/src/test/java/com/catveloper365/studyshop/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/catveloper365/studyshop/repository/ItemRepositoryTest.java
@@ -113,7 +113,7 @@ class ItemRepositoryTest {
 
     @Test
     @DisplayName("상품명 조회")
-    void findByItemNmTest() {
+    void findByItemNm() {
         //given
         this.createItemList();
 
@@ -131,7 +131,7 @@ class ItemRepositoryTest {
 
     @Test
     @DisplayName("상품명, 상품 상세 설명 모두 존재")
-    public void findNmOrDetailBoth() throws Exception {
+    public void findByNmOrDetailBoth() throws Exception {
         //given
         this.createItemList();
 
@@ -150,7 +150,7 @@ class ItemRepositoryTest {
 
     @Test
     @DisplayName("상품명, 상품 상세 설명 중 1개만 존재")
-    void findNmOrDetailOne() throws Exception {
+    void findByNmOrDetailOne() throws Exception {
         //given
         this.createItemList();
 
@@ -165,6 +165,41 @@ class ItemRepositoryTest {
 //        }
         assertThat(itemList.size()).isEqualTo(1);
         assertThat(findItemDetail).isEqualTo(itemList.get(0).getItemDetail());
+    }
+
+    @Test
+    @DisplayName("가격 LessThan 상품 오름차순 조회")
+    void findByPriceLessThanAsc() throws Exception {
+        //given
+        this.createItemList();
+
+        //when
+        List<Item> itemList = itemRepository.findByPriceLessThan(10005);
+
+        //then
+        for (Item item : itemList) {
+            System.out.println("item = " + item);
+        }
+        assertThat(itemList.size()).isEqualTo(4);
+        assertThat(itemList.get(0).getPrice()).isBetween(10001, 10004);
+        assertThat(itemList.get(0).getPrice()).isEqualTo(10001);
+    }
+    
+    @Test
+    @DisplayName("가격 LessThan 상품 내림차순 조회")
+    void findByPriceLessThanDesc() throws Exception {
+        //given
+        this.createItemList();
+
+        //when
+        List<Item> itemList = itemRepository.findByPriceLessThanOrderByPriceDesc(10005);
+
+        //then
+        for (Item item : itemList) {
+            System.out.println("item = " + item);
+        }
+        assertThat(itemList.size()).isEqualTo(4);
+        assertThat(itemList.get(0).getPrice()).isEqualTo(10004);
     }
 
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,22 @@
+# test DB\uB85C h2 DB\uB97C \uC778\uBA54\uBAA8\uB9AC \uBC29\uC2DD\uC73C\uB85C \uC0AC\uC6A9\uD558\uB3C4\uB85D \uC124\uC815
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.url=jdbc:h2:mem:test
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.h2.console.enabled=true
+
+# h2 DB \uBC29\uC5B8 \uC124\uC815
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+# \uC2E4\uD589\uB418\uB294 \uCFFC\uB9AC\uB97C \uCF58\uC194\uC5D0 \uCD9C\uB825
+spring.jpa.properties.hibernate.show_sql=true
+
+# \uCF58\uC194\uCC3D\uC5D0 \uCD9C\uB825\uB418\uB294 \uCFFC\uB9AC\uB97C \uAC00\uB3C5\uC131 \uC88B\uAC8C \uD3EC\uB9F7\uD305
+spring.jpa.properties.hibernate.format_sql=true
+
+# \uCFFC\uB9AC \uBC14\uC778\uB4DC \uD30C\uB77C\uBBF8\uD130 \uAC12 \uCD9C\uB825
+logging.level.org.hibernate.type.descriptor.sql=trace
+
+# \uCF58\uC194\uC5D0 \uC0C9 \uD45C\uC2DC
+spring.output.ansi.enabled=always


### PR DESCRIPTION
### 연관 이슈 관리
Closed: #4
Closes: #6 
Closes: #9 
Closes : #10
- 새롭게 알게 된 점
  - 키워드 1개 당 이슈 한 개만 처리할 수 있다
  - 즉, 관리하려는 이슈 갯수만큼 Closes를 적어줘야한다
  - #6, #9, #10 이슈는 직접 닫아줌

### 교재와 다르게 실습한 부분
1. 리포지토리 테스트
    - 교재에서는 `엔티티.toString()`으로 콘솔에 출력하여 눈으로 검증했지만, 나는 **AssertJ**를 사용하여 검증 로직 작성
    - **Spring Data JPA**가 제공하는 기본 CRUD 메서드 모두 테스트
    - `given-when-then` 테스트 패턴 사용
    - EntityManager를 clear()하여 영속성 컨텍스트가 아니라 DB에서 직접 조회한 값으로 검증을 수행
    - `@Query` 어노테이션의 파라미터 바인딩 방식 2개(이름 기반, 위치 기반) 모두 테스트
    - 테스트 데이터를 생성하는 메서드를 단건 생성/다건 생성으로 구성
      - 단건 생성 메서드를 활용하여 다건 생성
    - 쿼리메서드의 OR 키워드를 사용한 메서드를 2가지 상황으로 테스트
      - 두 조건을 모두 만족할 때
      - 두 조건 중 한 개만 만족할 때

2. 테스트 설정 파일을 다른 방법으로 지정
    - 교재에서는 테스트 클래스에서 어노테이션을 사용하여 지정했지만, 나는 test 패키지에 설정 파일을 생성하여 자동 지정되도록 함
