### PR TITLE
Part3-5. Thymeleaf를 통한 메인 페이지 구현 실습

### DIFF
--- a/src/main/java/com/catveloper365/studyshop/controller/MainController.java
+++ b/src/main/java/com/catveloper365/studyshop/controller/MainController.java
@@ -1,0 +1,12 @@
+package com.catveloper365.studyshop.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class MainController {
+    @GetMapping("/")
+    public String main() {
+        return "main";
+    }
+}

--- a/src/main/resources/static/css/layout1.css
+++ b/src/main/resources/static/css/layout1.css
@@ -1,0 +1,19 @@
+html {
+    position: relative;
+    min-height: 100%;
+    margin: 0;
+}
+body {
+    min-height: 100%;
+}
+.footer {
+    width: 100%;
+    padding: 15px 0;
+    text-align: center;
+}
+.content {
+    margin-bottom: 100px;
+    margin-top: 50px;
+    margin-left: 200px;
+    margin-right: 200px;
+}

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+    <div th:fragment="footer" class="footer">
+        <footer class="bg-transparent fixed-bottom">
+            <div class="py-3">
+                2020 Shopping Mall Example WebSite
+            </div>
+        </footer>
+    </div>
+</html>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+  <!-- 부트스트랩(버전 5.3.1)을 이용한 네비게이션 바 -->
+  <div th:fragment="header">
+    <nav class="navbar navbar-expand-lg bg-primary" data-bs-theme="dark">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="/">Shop</a>
+        <button class="navbar-toggler" type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#navbarSupportedContent"
+                aria-controls="navbarSupportedContent"
+                aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item">
+              <a class="nav-link" href="/admin/item/new">상품 등록</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/admin/items">상품 관리</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/cart">장바구니</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/orders">구매이력</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/members/login">로그인</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/members/logout">로그아웃</a>
+            </li>
+          </ul>
+          <form class="d-flex" role="search">
+            <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
+            <button class="btn btn-outline-success" type="submit">Search</button>
+          </form>
+        </div>
+      </div>
+    </nav>
+  </div>
+
+</html>

--- a/src/main/resources/templates/layouts/layout1.html
+++ b/src/main/resources/templates/layouts/layout1.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+    xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+
+    <!-- 부트스트랩 홈페이지에서 가져온 CDN, 버전 5.3.1 -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4bw+/aepP/YC94hEpVNVgiZdgIC5+VKNBQNGCHeKRQN+PtmoHDEXuppvnDJzQIu9" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
+
+    <link th:href="@{/css/layout1.css}" rel="stylesheet">
+
+    <th:block layout:fragment="script"></th:block>
+    <th:block layout:fragment="css"></th:block>
+</head>
+<body>
+    <div th:replace="fragments/header::header"></div>
+    <div layout:fragment="content" class="content">
+
+    </div>
+    <div th:replace="fragments/footer::footer"></div>
+</body>
+</html>

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/layout1}">
+
+  <div layout:fragment="content">
+     본문 영역입니다.
+  </div>
+</html>


### PR DESCRIPTION
### 연관 이슈 관리
Closes: #16 

### 교재와 다르게 실습한 부분
1. Part3-5를 위한 파일 새로 생성하여 실습
    - 교재에서는 Part3-4에서 생성한 파일들을 수정하여 사용
    - But Part3-1~4에서 실습한 소스들은 애플리케이션에 직접 사용할 소스들이 아니고, 단지 타임리프의 문법과 기능을 학습하기 위한 단순 예제이기때문에 `part3/ex-thymeleaf` 브랜치로 따로 분리하여 관리함
    - Part3-5의 실습 소스는 애플리케이션의 메인 페이지와 레이아웃으로 사용할 것이기때문에, `part3/dev-thymeleaf` 브랜치에서 파일을 새로 생성하여 작업함

2. 부트스트랩의 최신 버전 사용
    - 교재에서는 4.5.2 버전 사용, 나는 5.3.1 버전 사용
    - 사용한 버전이 다르기 때문에 네비게이션 바(Navbar)와 footer에 사용한 코드들도 다름
      - 5.3.1 버전의 공식 문서에서 가이드한 코드를 사용

3. footer를 하단에 배치하는 방법
    - 교재에서는 layout1.css 파일에 .footer 클래스 선택자로 위치 속성들을 직접 지정하여 footer를 하단에 배치함
    - 나는 부트스트랩의 `class="fixed-bottom"`을 사용함