### PR TITLE
Part4-3. 회원 가입 기능 구현 실습

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/src/main/java/com/catveloper365/studyshop/TestDataInit.java
+++ b/src/main/java/com/catveloper365/studyshop/TestDataInit.java
@@ -1,0 +1,31 @@
+package com.catveloper365.studyshop;
+
+import com.catveloper365.studyshop.dto.MemberFormDto;
+import com.catveloper365.studyshop.entity.Member;
+import com.catveloper365.studyshop.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+@Component
+@RequiredArgsConstructor
+public class TestDataInit {
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    /*
+    테스트용 데이터 생성
+     */
+    @PostConstruct
+    public void init() {
+        MemberFormDto memberFormDto = new MemberFormDto();
+        memberFormDto.setEmail("a@test.com");
+        memberFormDto.setName("홍길동");
+        memberFormDto.setAddress("행복시 행복동");
+        memberFormDto.setPassword("12345678");
+        Member member = Member.createMember(memberFormDto, passwordEncoder);
+        memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/catveloper365/studyshop/config/SecurityConfig.java
+++ b/src/main/java/com/catveloper365/studyshop/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 @Configuration
 @EnableWebSecurity
@@ -14,7 +15,9 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        return http.build();
+        return http.csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                .and()
+                .build();
     }
 
     @Bean

--- a/src/main/java/com/catveloper365/studyshop/constant/Role.java
+++ b/src/main/java/com/catveloper365/studyshop/constant/Role.java
@@ -1,0 +1,5 @@
+package com.catveloper365.studyshop.constant;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/java/com/catveloper365/studyshop/controller/MemberController.java
+++ b/src/main/java/com/catveloper365/studyshop/controller/MemberController.java
@@ -1,0 +1,23 @@
+package com.catveloper365.studyshop.controller;
+
+import com.catveloper365.studyshop.dto.MemberFormDto;
+import com.catveloper365.studyshop.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/new")
+    public String memberForm(Model model) {
+        model.addAttribute("memberFormDto", new MemberFormDto());
+        return "member/memberForm"; //회원 가입 페이지
+    }
+}

--- a/src/main/java/com/catveloper365/studyshop/controller/MemberController.java
+++ b/src/main/java/com/catveloper365/studyshop/controller/MemberController.java
@@ -1,12 +1,18 @@
 package com.catveloper365.studyshop.controller;
 
 import com.catveloper365.studyshop.dto.MemberFormDto;
+import com.catveloper365.studyshop.entity.Member;
 import com.catveloper365.studyshop.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.validation.Valid;
 
 @Controller
 @RequiredArgsConstructor
@@ -14,10 +20,29 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class MemberController {
 
     private final MemberService memberService;
+    private final PasswordEncoder passwordEncoder;
 
     @GetMapping("/new")
     public String memberForm(Model model) {
         model.addAttribute("memberFormDto", new MemberFormDto());
         return "member/memberForm"; //회원 가입 페이지
+    }
+
+    @PostMapping("/new")
+    public String memberForm(@Valid MemberFormDto memberFormDto, BindingResult bindingResult, Model model) {
+        if (bindingResult.hasErrors()) {
+            return "member/memberForm";
+        }
+
+        try {
+            Member member = Member.createMember(memberFormDto, passwordEncoder);
+            memberService.join(member);
+        } catch (IllegalStateException e) {
+            model.addAttribute("errorMessage", e.getMessage());
+            return "member/memberForm";
+        }
+
+        //회원 가입 성공 시 메인 페이지로 리다이렉트
+        return "redirect:/";
     }
 }

--- a/src/main/java/com/catveloper365/studyshop/controller/MemberController.java
+++ b/src/main/java/com/catveloper365/studyshop/controller/MemberController.java
@@ -11,6 +11,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.validation.Valid;
 
@@ -29,7 +30,7 @@ public class MemberController {
     }
 
     @PostMapping("/new")
-    public String memberForm(@Valid MemberFormDto memberFormDto, BindingResult bindingResult, Model model) {
+    public String memberForm(@Valid MemberFormDto memberFormDto, BindingResult bindingResult, RedirectAttributes redirectAttr) {
         if (bindingResult.hasErrors()) {
             return "member/memberForm";
         }
@@ -38,8 +39,8 @@ public class MemberController {
             Member member = Member.createMember(memberFormDto, passwordEncoder);
             memberService.join(member);
         } catch (IllegalStateException e) {
-            model.addAttribute("errorMessage", e.getMessage());
-            return "member/memberForm";
+            redirectAttr.addFlashAttribute("errorMessage", e.getMessage());
+            return "redirect:/members/new";
         }
 
         //회원 가입 성공 시 메인 페이지로 리다이렉트

--- a/src/main/java/com/catveloper365/studyshop/dto/MemberFormDto.java
+++ b/src/main/java/com/catveloper365/studyshop/dto/MemberFormDto.java
@@ -1,0 +1,16 @@
+package com.catveloper365.studyshop.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemberFormDto {
+    private String name;
+
+    private String email;
+
+    private String password;
+
+    private String address;
+}

--- a/src/main/java/com/catveloper365/studyshop/dto/MemberFormDto.java
+++ b/src/main/java/com/catveloper365/studyshop/dto/MemberFormDto.java
@@ -2,15 +2,26 @@ package com.catveloper365.studyshop.dto;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 
 @Getter
 @Setter
 public class MemberFormDto {
+    @NotBlank(message = "이름은 필수 입력 값입니다.")
     private String name;
 
+    @NotEmpty(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "이메일 형식으로 입력해주세요.")
     private String email;
 
+    @NotEmpty(message = "비밀번호는 필수 입력 값입니다.")
+    @Length(min=8, max=16, message = "비밀번호는 8자 이상, 16자 이하로 입력해주세요.")
     private String password;
 
+    @NotEmpty(message = "주소는 필수 입력 값입니다.")
     private String address;
 }

--- a/src/main/java/com/catveloper365/studyshop/entity/Member.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/Member.java
@@ -1,0 +1,47 @@
+package com.catveloper365.studyshop.entity;
+
+import com.catveloper365.studyshop.constant.Role;
+import com.catveloper365.studyshop.dto.MemberFormDto;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "member")
+@Getter
+@Setter
+@ToString
+public class Member {
+
+    @Id
+    @Column(name = "member_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Column(unique = true)
+    private String email;
+
+    private String password;
+
+    private String address;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    //Member 엔티티 객체를 생성하는 정적 팩토리 메서드
+    public static Member createMember(MemberFormDto memberFormDto, PasswordEncoder passwordEncoder) {
+        Member member = new Member();
+        member.setName(memberFormDto.getName());
+        member.setEmail(memberFormDto.getEmail());
+        member.setPassword(passwordEncoder.encode(memberFormDto.getPassword()));
+        member.setAddress(memberFormDto.getAddress());
+        member.setRole(Role.USER);
+        return member;
+    }
+
+}

--- a/src/main/java/com/catveloper365/studyshop/repository/MemberRepository.java
+++ b/src/main/java/com/catveloper365/studyshop/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.catveloper365.studyshop.repository;
+
+import com.catveloper365.studyshop.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Member findByEmail(String email);
+}

--- a/src/main/java/com/catveloper365/studyshop/service/MemberService.java
+++ b/src/main/java/com/catveloper365/studyshop/service/MemberService.java
@@ -1,0 +1,29 @@
+package com.catveloper365.studyshop.service;
+
+import com.catveloper365.studyshop.entity.Member;
+import com.catveloper365.studyshop.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public Member join(Member member) {
+        validateDuplicateMember(member);
+        return memberRepository.save(member);
+    }
+
+    //중복 회원 검사, 중복이면 예외 발생
+    private void validateDuplicateMember(Member member) {
+        Member findMember = memberRepository.findByEmail(member.getEmail());
+        if (findMember != null) {
+            throw new IllegalStateException("이미 가입된 회원입니다.");
+        }
+
+    }
+}

--- a/src/main/resources/templates/layouts/layout1.html
+++ b/src/main/resources/templates/layouts/layout1.html
@@ -9,6 +9,9 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4bw+/aepP/YC94hEpVNVgiZdgIC5+VKNBQNGCHeKRQN+PtmoHDEXuppvnDJzQIu9" crossorigin="anonymous">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
 
+    <!-- jquery -->
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+
     <link th:href="@{/css/layout1.css}" rel="stylesheet">
 
     <th:block layout:fragment="script"></th:block>

--- a/src/main/resources/templates/member/memberForm.html
+++ b/src/main/resources/templates/member/memberForm.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/layout1}">
+
+<div layout:fragment="content">
+    <h1 style="text-align:center">회원 가입</h1>
+    <form action="/members/new" role="form" method="post" th:object="${memberFormDto}">
+        <div class="mb-3">
+            <label th:for="name">이름</label>
+            <input type="text" th:field="*{name}" class="form-control" placeholder="이름을 입력해주세요">
+        </div>
+        <div class="mb-3">
+            <label th:for="email">이메일 주소</label>
+            <input type="email" th:field="*{email}" class="form-control" placeholder="이메일을 입력해주세요">
+        </div>
+        <div class="mb-3">
+            <label th:for="password">비밀번호</label>
+            <input type="password" th:field="*{password}" class="form-control" placeholder="비밀번호를 입력해주세요">
+        </div>
+        <div class="mb-3">
+            <label th:for="address">주소</label>
+            <input type="text" th:field="*{address}" class="form-control" placeholder="주소를 입력해주세요">
+        </div>
+        <div style="text-align:center">
+            <button type="submit" class="btn btn-primary">Submit</button>
+        </div>
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+    </form>
+</div>
+</html>

--- a/src/main/resources/templates/member/memberForm.html
+++ b/src/main/resources/templates/member/memberForm.html
@@ -3,24 +3,51 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layouts/layout1}">
 
+<!-- 사용자 CSS 추가 -->
+<th:block layout:fragment="css">
+    <style>
+        .fieldError {
+            color: #bd2130;
+        }
+    </style>
+</th:block>
+
+<!-- 사용자 스크립트 추가 -->
+<th:block layout:fragment="script">
+
+    <script th:inline="javascript">
+        $(document).ready(function(){
+            var errorMessage = [[${errorMessage}]];
+            if(errorMessage != null){
+                alert(errorMessage);
+            }
+        });
+    </script>
+
+</th:block>
+
 <div layout:fragment="content">
     <h1 style="text-align:center">회원 가입</h1>
     <form action="/members/new" role="form" method="post" th:object="${memberFormDto}">
         <div class="mb-3">
             <label th:for="name">이름</label>
             <input type="text" th:field="*{name}" class="form-control" placeholder="이름을 입력해주세요">
+            <p th:if="${#fields.hasErrors('name')}" th:errors="*{name}" class="fieldError">Incorrect data</p>
         </div>
         <div class="mb-3">
             <label th:for="email">이메일 주소</label>
             <input type="email" th:field="*{email}" class="form-control" placeholder="이메일을 입력해주세요">
+            <p th:if="${#fields.hasErrors('email')}" th:errors="*{email}" class="fieldError">Incorrect data</p>
         </div>
         <div class="mb-3">
             <label th:for="password">비밀번호</label>
             <input type="password" th:field="*{password}" class="form-control" placeholder="비밀번호를 입력해주세요">
+            <p th:if="${#fields.hasErrors('password')}" th:errors="*{password}" class="fieldError">Incorrect data</p>
         </div>
         <div class="mb-3">
             <label th:for="address">주소</label>
             <input type="text" th:field="*{address}" class="form-control" placeholder="주소를 입력해주세요">
+            <p th:if="${#fields.hasErrors('address')}" th:errors="*{address}" class="fieldError">Incorrect data</p>
         </div>
         <div style="text-align:center">
             <button type="submit" class="btn btn-primary">Submit</button>

--- a/src/test/java/com/catveloper365/studyshop/service/MemberServiceTest.java
+++ b/src/test/java/com/catveloper365/studyshop/service/MemberServiceTest.java
@@ -1,0 +1,67 @@
+package com.catveloper365.studyshop.service;
+
+import com.catveloper365.studyshop.dto.MemberFormDto;
+import com.catveloper365.studyshop.entity.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+
+    @Autowired
+    MemberService memberService;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    Member createMember() {
+        MemberFormDto memberFormDto = new MemberFormDto();
+        memberFormDto.setEmail("test@email.com");
+        memberFormDto.setName("홍길동");
+        memberFormDto.setAddress("서울시 마포구 합정동");
+        memberFormDto.setPassword("1234");
+        return Member.createMember(memberFormDto, passwordEncoder);
+    }
+
+    @Test
+    @DisplayName("회원가입 테스트")
+    void join() {
+        //given
+        Member member = createMember();
+
+        //when
+        Member joinedMember = memberService.join(member);
+
+        //then
+        //기댓값 : 저장하려고 요청했던 값, 실제 값 : 실제 저장된 값
+        assertEquals(member.getEmail(), joinedMember.getEmail());
+        assertEquals(member.getName(), joinedMember.getName());
+        assertEquals(member.getPassword(), joinedMember.getPassword());
+        assertEquals(member.getAddress(), joinedMember.getAddress());
+        assertEquals(member.getRole(), joinedMember.getRole());
+    }
+    
+    @Test
+    @DisplayName("중복 회원가입 테스트")
+    public void duplicatedJoin(){
+        //given
+        Member member1 = createMember();
+        Member member2 = createMember();
+
+        //when
+        Member joinedMember1 = memberService.join(member1);
+
+        //then
+        assertEquals(member1.getEmail(), joinedMember1.getEmail());
+        Throwable e = assertThrows(IllegalStateException.class, () -> memberService.join(member2));
+        assertEquals("이미 가입된 회원입니다.", e.getMessage());
+    }
+
+}


### PR DESCRIPTION
### 연관 이슈 관리
Closes: #20 

### 교재와 다르게 실습한 부분
1. 회원 가입 서비스 메서드명
    - 비즈니스 로직을 다루는 서비스 계층에서는 **비즈니스와 가까운 용어**를 사용하는 것이 좋다고 해서, 교재에서 사용한 **saveMember**보다는 **join**이 더 적합하다고 판단하여, 회원 가입을 위한 메서드명을 join으로 명명함
2. 회원 서비스 테스트 시 `given-when-then` 패턴 사용
3. 회원 가입 페이지의 form 관련 태그 속성
    - 교재와 부트스트랩 버전이 달라 form 관련 class 속성을 다르게 사용함
      - 교재 : `<div class="form-group>`
      - 나 : `<div class="mb-3">`
4. 회원 가입 요청 처리 로직에 `PRG` 패턴 적용
    - 교재에서는 중복 회원 가입 에러 메세지를 `Model` 인터페이스에 담아 다시 회원 가입 페이지로 return함
    - 이렇게 하면 새로고침 시 POST 요청이 계속 발생하는 문제가 발생
    - `Model` 인터페이스 대신 `RedirectAttributes` 인터페이스와 `PRG` 패턴을 적용하여 문제를 해결함
5. 스프링 시큐리티에 `CSRF` 관련 설정 추가
    - 교재의 Part4-3에는 없는 내용이지만, QnA 게시판을 참고하여 CSRF 토큰을 생성하여 쿠키에 저장하도록 설정을 추가함