### PR TITLE
Part4-4. 로그인/로그아웃 기능 구현 실습

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,10 @@
 			<scope>test</scope>
 			<version>${spring-security.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.thymeleaf.extras</groupId>
+			<artifactId>thymeleaf-extras-springsecurity5</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+			<version>${spring-security.version}</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/catveloper365/studyshop/config/SecurityConfig.java
+++ b/src/main/java/com/catveloper365/studyshop/config/SecurityConfig.java
@@ -8,18 +8,39 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
+    /**
+     * 특정 HTTP 요청에 대한 웹 기반 보안 구성
+     */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        return http.csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+
+        //CSRF 토큰 생성 설정
+        http.csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
+
+        //폼 기반 로그인/로그아웃 설정
+        http.formLogin()
+                .loginPage("/members/login")
+                .defaultSuccessUrl("/")
+                .usernameParameter("email")
+                .failureUrl("/members/login/error")
                 .and()
-                .build();
+                .logout()
+                .logoutRequestMatcher(new AntPathRequestMatcher("/members/logout"))
+                .logoutSuccessUrl("/")
+                .invalidateHttpSession(true); //로그아웃 후 세션을 전체 삭제할 지 여부 설정
+
+        return http.build();
     }
 
+    /**
+     * 패스워드를 암호화할 때 사용할 패스워드 인코더를 빈으로 등록
+     */
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();

--- a/src/main/java/com/catveloper365/studyshop/controller/MemberController.java
+++ b/src/main/java/com/catveloper365/studyshop/controller/MemberController.java
@@ -46,4 +46,15 @@ public class MemberController {
         //회원 가입 성공 시 메인 페이지로 리다이렉트
         return "redirect:/";
     }
+
+    @GetMapping("/login")
+    public String loginMember() {
+        return "member/memberLoginForm";
+    }
+
+    @GetMapping("/login/error")
+    public String loginError(Model model) {
+        model.addAttribute("loginErrorMsg", "아이디 또는 비밀번호를 확인해주세요");
+        return "member/memberLoginForm";
+    }
 }

--- a/src/main/java/com/catveloper365/studyshop/repository/MemberRepository.java
+++ b/src/main/java/com/catveloper365/studyshop/repository/MemberRepository.java
@@ -3,6 +3,8 @@ package com.catveloper365.studyshop.repository;
 import com.catveloper365.studyshop.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Member findByEmail(String email);
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/catveloper365/studyshop/service/MemberService.java
+++ b/src/main/java/com/catveloper365/studyshop/service/MemberService.java
@@ -3,6 +3,10 @@ package com.catveloper365.studyshop.service;
 import com.catveloper365.studyshop.entity.Member;
 import com.catveloper365.studyshop.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -10,7 +14,7 @@ import javax.transaction.Transactional;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class MemberService {
+public class MemberService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     public Member join(Member member) {
@@ -20,10 +24,21 @@ public class MemberService {
 
     //중복 회원 검사, 중복이면 예외 발생
     private void validateDuplicateMember(Member member) {
-        Member findMember = memberRepository.findByEmail(member.getEmail());
-        if (findMember != null) {
+        if (memberRepository.findByEmail(member.getEmail()).isPresent()) {
             throw new IllegalStateException("이미 가입된 회원입니다.");
         }
+    }
 
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member findMember = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException(email));
+
+        //스프링 시큐리티에서 제공하는 UserDetails 구현체인 User 생성하여 반환
+        return User.builder()
+                .username(findMember.getEmail())
+                .password(findMember.getPassword())
+                .roles(findMember.getRole().toString())
+                .build();
     }
 }

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 
   <!-- 부트스트랩(버전 5.3.1)을 이용한 네비게이션 바 -->
   <div th:fragment="header">
@@ -15,26 +16,26 @@
         </button>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-            <li class="nav-item">
+            <li class="nav-item" sec:authorize="hasAnyAuthority('ROLE_ADMIN')">
               <a class="nav-link" href="/admin/item/new">상품 등록</a>
             </li>
-            <li class="nav-item">
+            <li class="nav-item" sec:authorize="hasAnyAuthority('ROLE_ADMIN')">
               <a class="nav-link" href="/admin/items">상품 관리</a>
             </li>
-            <li class="nav-item">
+            <li class="nav-item" sec:authorize="isAuthenticated()">
               <a class="nav-link" href="/cart">장바구니</a>
             </li>
-            <li class="nav-item">
+            <li class="nav-item" sec:authorize="isAuthenticated()">
               <a class="nav-link" href="/orders">구매이력</a>
             </li>
-            <li class="nav-item">
+            <li class="nav-item" sec:authorize="isAnonymous()">
               <a class="nav-link" href="/members/login">로그인</a>
             </li>
-            <li class="nav-item">
+            <li class="nav-item" sec:authorize="isAuthenticated()">
               <a class="nav-link" href="/members/logout">로그아웃</a>
             </li>
           </ul>
-          <form class="d-flex" role="search">
+          <form class="d-flex" role="search" th:action="@{/}" method="get">
             <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
             <button class="btn btn-outline-success" type="submit">Search</button>
           </form>

--- a/src/main/resources/templates/member/memberLoginForm.html
+++ b/src/main/resources/templates/member/memberLoginForm.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/layout1}">
+
+<!-- 사용자 CSS 추가 -->
+<th:block layout:fragment="css">
+    <style>
+        .error {
+            color: #bd2130;
+        }
+    </style>
+</th:block>
+
+<div layout:fragment="content">
+    <h1 style="text-align:center">로그인</h1>
+    <form action="/members/login" role="form" method="post">
+        <div class="mb-3">
+            <label th:for="email">이메일 주소</label>
+            <input type="email" name="email" class="form-control" placeholder="이메일을 입력해주세요">
+        </div>
+        <div class="mb-3">
+            <label th:for="password">비밀번호</label>
+            <input type="password" name="password" id="password" class="form-control" placeholder="비밀번호를 입력해주세요">
+        </div>
+        <p th:if="${loginErrorMsg}" class="error" th:text="${loginErrorMsg}"></p>
+        <button class="btn btn-primary">로그인</button>
+        <button type="button" class="btn btn-primary" onClick="location.href='/members/new'">회원 가입</button>
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+    </form>
+</div>
+</html>

--- a/src/test/java/com/catveloper365/studyshop/controller/MemberControllerTest.java
+++ b/src/test/java/com/catveloper365/studyshop/controller/MemberControllerTest.java
@@ -1,0 +1,97 @@
+package com.catveloper365.studyshop.controller;
+
+import com.catveloper365.studyshop.dto.MemberFormDto;
+import com.catveloper365.studyshop.entity.Member;
+import com.catveloper365.studyshop.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders;
+import org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.ResultHandler;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class MemberControllerTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    public Member createMember(String email, String password) {
+        MemberFormDto dto = new MemberFormDto();
+        dto.setEmail(email);
+        dto.setName("홍길동");
+        dto.setAddress("서울시 마포구 합정동");
+        dto.setPassword(password);
+        Member member = Member.createMember(dto, passwordEncoder);
+        return memberService.join(member);
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    public void loginSuccess() throws Exception {
+        //given
+        String email = "test@email.com";
+        String password = "1234";
+        this.createMember(email, password);
+
+        //when
+        ResultActions resultLogin = mockMvc.perform(formLogin()
+                .userParameter("email")
+                .loginProcessingUrl("/members/login")
+                .user(email).password(password));
+
+        //then
+        resultLogin.andExpect(SecurityMockMvcResultMatchers.authenticated());
+
+        //when
+        ResultActions resultLogout = mockMvc.perform(SecurityMockMvcRequestBuilders.logout("/members/logout"));
+
+        //then
+        resultLogout.andExpect(SecurityMockMvcResultMatchers.unauthenticated());
+    }
+
+    @Test
+    @DisplayName("로그인 실패")
+    public void loginFail() throws Exception {
+        //given
+        String email = "test@email.com";
+        String password = "1234";
+        this.createMember(email, password);
+
+        //when
+        ResultActions resultLogin = mockMvc.perform(formLogin()
+                .userParameter("email")
+                .loginProcessingUrl("/members/login")
+                .user(email).password("12345"));
+
+        //then
+        resultLogin.andExpect(SecurityMockMvcResultMatchers.unauthenticated());
+
+        //when
+        //로그인에 실패하면 /members/login/error GET 요청이 발생
+        ResultActions resultError = mockMvc.perform(MockMvcRequestBuilders.get("/members/login/error"));
+
+        //then
+        resultError.andExpect(MockMvcResultMatchers.model().attribute("loginErrorMsg","아이디 또는 비밀번호를 확인해주세요"));
+    }
+
+}

--- a/src/test/java/com/catveloper365/studyshop/controller/MemberControllerTest.java
+++ b/src/test/java/com/catveloper365/studyshop/controller/MemberControllerTest.java
@@ -46,8 +46,8 @@ class MemberControllerTest {
     }
 
     @Test
-    @DisplayName("로그인 성공")
-    public void loginSuccess() throws Exception {
+    @DisplayName("로그인/로그아웃 성공")
+    public void loginLogoutSuccess() throws Exception {
         //given
         String email = "test@email.com";
         String password = "1234";


### PR DESCRIPTION
### 연관 이슈 관리
Closes: #22 

### 교재와 다르게 실습한 부분
1. MemberRepository의 findByEmail 메서드 반환값을 `Optional`로 변경
    - `loadUserByUsername` 메서드 구현 시, findByEmail 수행 결과가 null일 때 예외를 발생시키는 로직을 람다식을 사용하여 작성할 수 있게 됨
2. Security 설정 파일의 설정 추가
    - 폼 기반 로그인/로그아웃 설정에 `invalidateHttpSession(true);` 설정 추가
        - [참고 도서 : 스프링 부트 3 백엔드 개발자 되기 - 자바 편 Ch08. 스프링 시큐리티로 로그인/로그아웃, 회원 가입 구현하기](https://product.kyobobook.co.kr/detail/S000201766024)
        - but 설정에 따라 로그아웃 시 세션 삭제 여부가 달라지는 지 확인하지 못함
3. 로그인 페이지의 form 관련 태그 속성
    - 교재와 부트스트랩 버전이 달라 form 관련 class 속성을 다르게 사용함
      - 교재 : `<div class="form-group>`
      - 나 : `<div class="mb-3">`
4. 회원 컨트롤러 테스트 코드
    - 교재 : 로그인 성공, 로그인 실패에 대해서만 테스트 코드 작성
    - 나
      - 로그인 성공 테스트에 로그아웃 테스트 코드도 추가
      - 로그인 실패 테스트에 로그인 에러 메세지 검증 로직도 추가