### PR TITLE
Part4-5. 페이지 권한 설정 실습

### DIFF
--- a/src/main/java/com/catveloper365/studyshop/TestDataInit.java
+++ b/src/main/java/com/catveloper365/studyshop/TestDataInit.java
@@ -1,5 +1,6 @@
 package com.catveloper365.studyshop;
 
+import com.catveloper365.studyshop.constant.Role;
 import com.catveloper365.studyshop.dto.MemberFormDto;
 import com.catveloper365.studyshop.entity.Member;
 import com.catveloper365.studyshop.repository.MemberRepository;
@@ -26,6 +27,7 @@ public class TestDataInit {
         memberFormDto.setAddress("행복시 행복동");
         memberFormDto.setPassword("12345678");
         Member member = Member.createMember(memberFormDto, passwordEncoder);
+        member.setRole(Role.ADMIN); //ADMIN 권한으로 생성
         memberRepository.save(member);
     }
 }

--- a/src/main/java/com/catveloper365/studyshop/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/catveloper365/studyshop/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,17 @@
+package com.catveloper365.studyshop.config;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+    }
+}

--- a/src/main/java/com/catveloper365/studyshop/config/SecurityConfig.java
+++ b/src/main/java/com/catveloper365/studyshop/config/SecurityConfig.java
@@ -35,6 +35,17 @@ public class SecurityConfig {
                 .logoutSuccessUrl("/")
                 .invalidateHttpSession(true); //로그아웃 후 세션을 전체 삭제할 지 여부 설정
 
+        //요청에 대한 인증/인가 설정
+        http.authorizeRequests()
+                .mvcMatchers("/css/**", "/js/**", "/img/**").permitAll() //static 디렉터리는 인증 필요없음
+                .mvcMatchers("/", "/members/**", "/item/**", "/images/**").permitAll() //인증 없이 모든 사용자가 접근 가능
+                .mvcMatchers("/admin/**").hasRole("ADMIN") //해당 계정이 ADMIN 권한일 때만 접근 가능
+                .anyRequest().authenticated(); //그 외 모든 요청은 인증이 필요
+
+        //인증되지 않은 사용자가 리소스에 접근했을 때 수행되는 핸들러 등록
+        http.exceptionHandling()
+                .authenticationEntryPoint(new CustomAuthenticationEntryPoint());
+
         return http.build();
     }
 

--- a/src/main/java/com/catveloper365/studyshop/controller/ItemController.java
+++ b/src/main/java/com/catveloper365/studyshop/controller/ItemController.java
@@ -1,0 +1,13 @@
+package com.catveloper365.studyshop.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class ItemController {
+    
+    @GetMapping("/admin/item/new")
+    public String itemForm() {
+        return "item/itemForm";
+    }
+}

--- a/src/main/resources/templates/item/itemForm.html
+++ b/src/main/resources/templates/item/itemForm.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/layout1}">
+
+<div layout:fragment="content">
+    <h1>상품 등록 페이지입니다.</h1>
+</div>
+
+</html>

--- a/src/test/java/com/catveloper365/studyshop/controller/ItemControllerTest.java
+++ b/src/test/java/com/catveloper365/studyshop/controller/ItemControllerTest.java
@@ -1,0 +1,64 @@
+package com.catveloper365.studyshop.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ItemControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    @DisplayName("상품 등록 페이지 ADMIN 회원 접근")
+    @WithMockUser(username = "admin", roles="ADMIN")
+    public void itemForm() throws Exception {
+        //given
+
+        //when
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/admin/item/new"));
+
+        //then
+        resultActions.andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("상품 등록 페이지 일반 회원 접근")
+    @WithMockUser(username = "user", roles = "USER")
+    public void itemFormNotAdmin() throws Exception {
+        //given
+
+        //when
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/admin/item/new"));
+
+        //then
+        resultActions.andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("상품 등록 페이지 미인증 사용자 접근")
+    public void itemFormUnauthenticated() throws Exception {
+        //given
+
+        //when
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/admin/item/new"));
+
+        //then
+        resultActions.andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+}


### PR DESCRIPTION
### 연관 이슈 관리
Closes: #24 

### 교재와 다르게 실습한 부분
1. ADMIN 권한 계정 생성 방법
    - TestDataInit 클래스를 통해 애플리케이션 실행 시에 자동으로 생성되는 테스트 데이터를 ADMIN 권한으로 생성하도록 변경
    - #24 의 진행 중 이슈 2번에 해당하는 내용

2. 유저 접근 권한 테스트 케이스 추가
    - 교재 : ADMIN 권한의 계정/일반 USER 권한의 계정으로 상품 등록 페이지에 접근했을 때 각각 테스트
    - 나 : 로그인하지 않은 사용자가 상품 등록 페이지에 접근했을 때 테스트 케이스 추가 