### PR TITLE
Part5-1. 연관 관계 맵핑 종류 실습

### DIFF
--- a/src/main/java/com/catveloper365/studyshop/constant/OrderStatus.java
+++ b/src/main/java/com/catveloper365/studyshop/constant/OrderStatus.java
@@ -1,0 +1,5 @@
+package com.catveloper365.studyshop.constant;
+
+public enum OrderStatus {
+    ORDER, CANCEL
+}

--- a/src/main/java/com/catveloper365/studyshop/entity/Cart.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/Cart.java
@@ -1,0 +1,24 @@
+package com.catveloper365.studyshop.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "cart")
+@Getter
+@Setter
+@ToString
+public class Cart {
+
+    @Id
+    @Column(name = "cart_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/catveloper365/studyshop/entity/CartItem.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/CartItem.java
@@ -1,0 +1,28 @@
+package com.catveloper365.studyshop.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "cart_item")
+@Getter
+@Setter
+public class CartItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cart_item_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "cart_id")
+    private Cart cart;
+
+    @ManyToOne
+    @JoinColumn(name = "item_id")
+    private Item item;
+
+    private int count;
+}

--- a/src/main/java/com/catveloper365/studyshop/entity/Order.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/Order.java
@@ -1,0 +1,38 @@
+package com.catveloper365.studyshop.entity;
+
+import com.catveloper365.studyshop.constant.OrderStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "orders")
+@Getter
+@Setter
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private LocalDateTime orderDate; //주문일
+
+    @Enumerated(EnumType.STRING)
+    private OrderStatus orderStatus; //주문 상태
+
+    @OneToMany(mappedBy = "order")
+    private List<OrderItem> orderItems = new ArrayList<>();
+
+    private LocalDateTime regTime;
+
+    private LocalDateTime updateTime;
+}

--- a/src/main/java/com/catveloper365/studyshop/entity/OrderItem.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/OrderItem.java
@@ -1,0 +1,35 @@
+package com.catveloper365.studyshop.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "order_item")
+@Getter
+@Setter
+public class OrderItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_item_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "item_id")
+    private Item item;
+
+    @ManyToOne
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    private int orderPrice; //주문 가격
+
+    private int count; //수량
+
+    private LocalDateTime regTime;
+
+    private LocalDateTime updateTime;
+}

--- a/src/main/java/com/catveloper365/studyshop/repository/CartRepository.java
+++ b/src/main/java/com/catveloper365/studyshop/repository/CartRepository.java
@@ -1,0 +1,7 @@
+package com.catveloper365.studyshop.repository;
+
+import com.catveloper365.studyshop.entity.Cart;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+}

--- a/src/test/java/com/catveloper365/studyshop/entity/CartTest.java
+++ b/src/test/java/com/catveloper365/studyshop/entity/CartTest.java
@@ -1,0 +1,66 @@
+package com.catveloper365.studyshop.entity;
+
+import com.catveloper365.studyshop.dto.MemberFormDto;
+import com.catveloper365.studyshop.repository.CartRepository;
+import com.catveloper365.studyshop.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityNotFoundException;
+import javax.persistence.PersistenceContext;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class CartTest {
+
+    @Autowired
+    CartRepository cartRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @PersistenceContext
+    EntityManager em;
+
+    Member createMember() {
+        MemberFormDto dto = new MemberFormDto();
+        dto.setEmail("test@email.com");
+        dto.setName("홍길동");
+        dto.setAddress("서울시 마포구 합정동");
+        dto.setPassword("1234");
+        return Member.createMember(dto, passwordEncoder);
+    }
+
+    @Test
+    @DisplayName("장바구니 회원 엔티티 맵핑 조회")
+    public void findCartAndMember(){
+        //given
+        Member member = this.createMember();
+        memberRepository.save(member); //회원 엔티티 영속성 컨텍스트에 저장
+
+        Cart cart = new Cart();
+        cart.setMember(member);
+        cartRepository.save(cart); //장바구니 엔티티 영속성 컨텍스트에 저장
+
+        //when
+        em.flush(); //영속성 컨텍스트에 저장된 엔티티를 DB에 강제 반영
+        em.clear(); //영속성 컨텍스트를 비워 DB에서 조회하도록 함
+
+        Cart savedCart = cartRepository.findById(cart.getId())
+                .orElseThrow(EntityNotFoundException::new);
+
+        //then
+        assertEquals(savedCart.getMember().getId(), member.getId());
+    }
+
+}


### PR DESCRIPTION
### 연관 이슈 관리
Closes: #26 

### 교재와 다르게 실습한 부분
1. 기본키 생성 전략 `GenerationType.IDENTITY` 사용
    - 교재:  `AUTO` 전략(default 이기 때문에 생략하면 자동으로 AUTO 전략 적용)사용
    - 나 :  MySQL DB에 맞춰 `IDENTITY` 전략 사용
    - #7 과 동일한 내용임