### PR TITLE
Part5-2. 영속성 전이 실습

### DIFF
--- a/src/main/java/com/catveloper365/studyshop/entity/Order.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/Order.java
@@ -29,7 +29,8 @@ public class Order {
     @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus; //주문 상태
 
-    @OneToMany(mappedBy = "order")
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL,
+            orphanRemoval = true)
     private List<OrderItem> orderItems = new ArrayList<>();
 
     private LocalDateTime regTime;

--- a/src/main/java/com/catveloper365/studyshop/repository/OrderRepository.java
+++ b/src/main/java/com/catveloper365/studyshop/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.catveloper365.studyshop.repository;
+
+import com.catveloper365.studyshop.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/test/java/com/catveloper365/studyshop/entity/OrderTest.java
+++ b/src/test/java/com/catveloper365/studyshop/entity/OrderTest.java
@@ -1,0 +1,125 @@
+package com.catveloper365.studyshop.entity;
+
+import com.catveloper365.studyshop.constant.ItemSellStatus;
+import com.catveloper365.studyshop.repository.ItemRepository;
+import com.catveloper365.studyshop.repository.MemberRepository;
+import com.catveloper365.studyshop.repository.OrderRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityNotFoundException;
+import javax.persistence.PersistenceContext;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class OrderTest {
+
+    @Autowired
+    OrderRepository orderRepository;
+
+    @Autowired
+    ItemRepository itemRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @PersistenceContext
+    EntityManager em;
+
+    Item createItem(int num) {
+        Item item = new Item();
+        item.setItemNm("테스트 상품" + num);
+        item.setPrice(10000);
+        item.setItemDetail("상세 설명" + num);
+        item.setItemSellStatus(ItemSellStatus.SELL);
+        item.setStockNumber(100);
+        item.setRegTime(LocalDateTime.now());
+        item.setUpdateTime(LocalDateTime.now());
+        return item;
+    }
+
+    Order createOrder(int itemCnt) {
+        Order order = new Order();
+
+        for (int i = 1; i <= itemCnt; i++) {
+            Item item = this.createItem(i);
+            itemRepository.save(item);
+
+            OrderItem orderItem = new OrderItem();
+            orderItem.setItem(item);
+            orderItem.setCount(10);
+            orderItem.setOrderPrice(1000);
+            orderItem.setOrder(order);
+
+            //orderItem은 영속성 컨텍스트에 저장X
+            order.getOrderItems().add(orderItem);
+        }
+        return order;
+    }
+
+    @Test
+    @DisplayName("저장 영속성 전이")
+    void cascadeSave(){
+        //given
+        Order order = this.createOrder(3);
+
+        //order 엔티티 저장 & 강제 flush를 통해 DB 반영
+        orderRepository.saveAndFlush(order);
+        em.clear(); //영속성 컨텍스트의 상태 초기화
+
+        //when
+        Order savedOrder = orderRepository.findById(order.getId())
+                .orElseThrow(EntityNotFoundException::new);
+
+        //then
+        assertEquals(3, savedOrder.getOrderItems().size());
+    }
+    @Test
+    @DisplayName("삭제 영속성 전이")
+    void cascadeRemove(){
+        //given
+        Order order = this.createOrder(3);
+        orderRepository.save(order);
+
+        //when
+        orderRepository.delete(order);
+        em.flush();
+        em.clear();
+
+        //then
+        assertThrows(EntityNotFoundException.class, ()->{
+            orderRepository.findById(order.getId())
+                    .orElseThrow(EntityNotFoundException::new);
+        });
+    }
+
+    @Test
+    @DisplayName("고아객체 제거")
+    void orphanRemoval(){
+        //given
+        Order order = this.createOrder(3);
+        orderRepository.save(order);
+
+        //when
+        order.getOrderItems().remove(0);
+        em.flush();
+        em.clear();
+
+        Order savedOrder = orderRepository.findById(order.getId())
+                .orElseThrow(EntityNotFoundException::new);
+
+        //then
+        assertEquals(2, savedOrder.getOrderItems().size());
+        assertEquals("테스트 상품2", savedOrder.getOrderItems().get(0).getItem().getItemNm());
+    }
+
+
+}


### PR DESCRIPTION
### 연관 이슈 관리
Closes: #28 

### 교재와 다르게 실습한 부분
1. Order 엔티티 테스트 코드
    - 코드 재사용, 검증 편의를 고려하여 **createItem()**, **createOrder()** 메서드를 교재와 조금 다르게 작성
      - 주문 엔티티와 주문 상품 엔티티 간의 영속성 전이, 고아객체 제거 기능을 테스트하기 위해 주문 데이터를 생성하는 createOrder() 메서드에서 굳이 빈 member 객체를 생성 및 연결해 줄 필요가 없어 해당 코드 제거
      - createOrder() 메서드는 실제적으로 주문 데이터를 만드는 코드만을 담당하는 것이 적절하다 판단하여, `orderRepository.save()` 코드는 밖으로 빼냄
      - createItem() 메서드에 int num 파라미터를 추가하여 상품명을 다르게 생성하도록 하고, 이를 활용하여 검증 코드 작성
      - 결과적으로 createOrder() 메서드를 3개의 테스트 케이스에서 모두 사용할 수 있게 됨
    - 고아객체 제거 테스트에 검증 코드 추가
    - 영속성 전이 REMOVE 옵션에 대한 테스트 케이스 추가 작성