### PR TITLE
Part5-4. Auditing을 이용한 엔티티 공통 속성 공통화 실습

### DIFF
--- a/src/main/java/com/catveloper365/studyshop/config/AuditConfig.java
+++ b/src/main/java/com/catveloper365/studyshop/config/AuditConfig.java
@@ -1,0 +1,15 @@
+package com.catveloper365.studyshop.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class AuditConfig {
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return new AuditorAwareImpl();
+    }
+}

--- a/src/main/java/com/catveloper365/studyshop/config/AuditorAwareImpl.java
+++ b/src/main/java/com/catveloper365/studyshop/config/AuditorAwareImpl.java
@@ -1,0 +1,20 @@
+package com.catveloper365.studyshop.config;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+public class AuditorAwareImpl implements AuditorAware<String > {
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String userId = "";
+        if (authentication != null) {
+            userId = authentication.getName(); //로그인한 사용자의 이름
+        }
+
+        return Optional.of(userId);
+    }
+}

--- a/src/main/java/com/catveloper365/studyshop/entity/BaseEntity.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.catveloper365.studyshop.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+@EntityListeners(value = {AuditingEntityListener.class})
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity extends BaseTimeEntity{
+
+    @CreatedBy
+    @Column(updatable = false)
+    private String createBy;
+
+    @LastModifiedBy
+    private String  modifiedBy;
+}

--- a/src/main/java/com/catveloper365/studyshop/entity/BaseEntity.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/BaseEntity.java
@@ -16,7 +16,7 @@ public abstract class BaseEntity extends BaseTimeEntity{
 
     @CreatedBy
     @Column(updatable = false)
-    private String createBy;
+    private String createdBy;
 
     @LastModifiedBy
     private String  modifiedBy;

--- a/src/main/java/com/catveloper365/studyshop/entity/BaseTimeEntity.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/BaseTimeEntity.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 
 @EntityListeners(value = {AuditingEntityListener.class})
 @MappedSuperclass
-@Getter @Setter
+@Getter
 public abstract class BaseTimeEntity {
 
     @CreatedDate

--- a/src/main/java/com/catveloper365/studyshop/entity/BaseTimeEntity.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.catveloper365.studyshop.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@EntityListeners(value = {AuditingEntityListener.class})
+@MappedSuperclass
+@Getter @Setter
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime regTime;
+
+    @LastModifiedDate
+    private LocalDateTime updateTime;
+}

--- a/src/main/java/com/catveloper365/studyshop/entity/Cart.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/Cart.java
@@ -11,7 +11,7 @@ import javax.persistence.*;
 @Getter
 @Setter
 @ToString
-public class Cart {
+public class Cart extends BaseEntity{
 
     @Id
     @Column(name = "cart_id")

--- a/src/main/java/com/catveloper365/studyshop/entity/CartItem.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/CartItem.java
@@ -9,7 +9,7 @@ import javax.persistence.*;
 @Table(name = "cart_item")
 @Getter
 @Setter
-public class CartItem {
+public class CartItem extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/catveloper365/studyshop/entity/Item.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/Item.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @ToString
-public class Item {
+public class Item extends BaseEntity {
     @Id
     @Column(name = "item_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,8 +34,4 @@ public class Item {
 
     @Enumerated(EnumType.STRING)
     private ItemSellStatus itemSellStatus; //상품 판매 상태
-
-    private LocalDateTime regTime; //등록 시간
-    
-    private LocalDateTime updateTime; //수정 시간
 }

--- a/src/main/java/com/catveloper365/studyshop/entity/Member.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/Member.java
@@ -14,7 +14,7 @@ import javax.persistence.*;
 @Getter
 @Setter
 @ToString
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
     @Column(name = "member_id")

--- a/src/main/java/com/catveloper365/studyshop/entity/Order.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/Order.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Table(name = "orders")
 @Getter
 @Setter
-public class Order {
+public class Order extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,8 +32,4 @@ public class Order {
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL,
             orphanRemoval = true, fetch = FetchType.LAZY)
     private List<OrderItem> orderItems = new ArrayList<>();
-
-    private LocalDateTime regTime;
-
-    private LocalDateTime updateTime;
 }

--- a/src/main/java/com/catveloper365/studyshop/entity/OrderItem.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/OrderItem.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @Table(name = "order_item")
 @Getter
 @Setter
-public class OrderItem {
+public class OrderItem extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,7 +29,4 @@ public class OrderItem {
 
     private int count; //수량
 
-    private LocalDateTime regTime;
-
-    private LocalDateTime updateTime;
 }

--- a/src/test/java/com/catveloper365/studyshop/entity/MemberTest.java
+++ b/src/test/java/com/catveloper365/studyshop/entity/MemberTest.java
@@ -1,7 +1,6 @@
 package com.catveloper365.studyshop.entity;
 
 import com.catveloper365.studyshop.repository.MemberRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,10 +12,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityNotFoundException;
 import javax.persistence.PersistenceContext;
 
-import java.time.LocalDateTime;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
@@ -44,16 +40,16 @@ class MemberTest {
                 .orElseThrow(EntityNotFoundException::new);
 
         //then
-        System.out.println("savedMember.getCreateBy() = " + savedMember.getCreateBy());
+        System.out.println("savedMember.getCreateBy() = " + savedMember.getCreatedBy());
         System.out.println("savedMember.getModifiedBy() = " + savedMember.getModifiedBy());
         System.out.println("savedMember.getRegTime() = " + savedMember.getRegTime());
         System.out.println("savedMember.getUpdateTime() = " + savedMember.getUpdateTime());
 
-        assertThat(savedMember.getCreateBy()).isNotEmpty();
+        assertThat(savedMember.getCreatedBy()).isNotEmpty();
         assertThat(savedMember.getModifiedBy()).isNotEmpty();
         assertThat(savedMember.getRegTime()).isNotNull();
         assertThat(savedMember.getUpdateTime()).isNotNull();
-        assertThat(savedMember.getCreateBy()).isEqualTo(member.getCreateBy());
+        assertThat(savedMember.getCreatedBy()).isEqualTo(member.getCreatedBy());
     }
 
     @Test

--- a/src/test/java/com/catveloper365/studyshop/entity/MemberTest.java
+++ b/src/test/java/com/catveloper365/studyshop/entity/MemberTest.java
@@ -1,0 +1,93 @@
+package com.catveloper365.studyshop.entity;
+
+import com.catveloper365.studyshop.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityNotFoundException;
+import javax.persistence.PersistenceContext;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class MemberTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @PersistenceContext
+    EntityManager em;
+
+    @Test
+    @DisplayName("저장 시 Auditing")
+    @WithMockUser(username = "save@test.com", roles = "USER")
+    public void auditingSave(){
+        //given
+        Member member = new Member();
+        memberRepository.save(member);
+
+        em.flush();
+        em.clear();
+
+        //when
+        Member savedMember = memberRepository.findById(member.getId())
+                .orElseThrow(EntityNotFoundException::new);
+
+        //then
+        System.out.println("savedMember.getCreateBy() = " + savedMember.getCreateBy());
+        System.out.println("savedMember.getModifiedBy() = " + savedMember.getModifiedBy());
+        System.out.println("savedMember.getRegTime() = " + savedMember.getRegTime());
+        System.out.println("savedMember.getUpdateTime() = " + savedMember.getUpdateTime());
+
+        assertThat(savedMember.getCreateBy()).isNotEmpty();
+        assertThat(savedMember.getModifiedBy()).isNotEmpty();
+        assertThat(savedMember.getRegTime()).isNotNull();
+        assertThat(savedMember.getUpdateTime()).isNotNull();
+        assertThat(savedMember.getCreateBy()).isEqualTo(member.getCreateBy());
+    }
+
+    @Test
+    @DisplayName("update 시 Auditing")
+    @WithMockUser(username = "update@test.com", roles = "USER")
+    public void auditingUpdate(){
+        //given
+        Member member = new Member();
+        memberRepository.save(member);
+
+        em.flush();
+        em.clear();
+
+        Member savedMember = memberRepository.findById(member.getId())
+                .orElseThrow(EntityNotFoundException::new);
+
+        //when
+        savedMember.setName("hong");
+
+        em.flush();
+        em.clear();
+
+        Member updatedMember = memberRepository.findById(member.getId())
+                .orElseThrow(EntityNotFoundException::new);
+
+        //then
+        System.out.println("savedMember.getRegTime() = " + savedMember.getRegTime());
+        System.out.println("savedMember.getUpdateTime() = " + savedMember.getUpdateTime());
+
+        System.out.println("updatedMember.getRegTime() = " + updatedMember.getRegTime());
+        System.out.println("updatedMember.getUpdateTime() = " + updatedMember.getUpdateTime());
+
+        assertThat(savedMember.getRegTime()).isEqualTo(updatedMember.getRegTime());
+        assertThat(savedMember.getUpdateTime()).isNotEqualTo(updatedMember.getUpdateTime());
+    }
+
+}

--- a/src/test/java/com/catveloper365/studyshop/entity/OrderTest.java
+++ b/src/test/java/com/catveloper365/studyshop/entity/OrderTest.java
@@ -41,8 +41,6 @@ class OrderTest {
         item.setItemDetail("상세 설명" + num);
         item.setItemSellStatus(ItemSellStatus.SELL);
         item.setStockNumber(100);
-        item.setRegTime(LocalDateTime.now());
-        item.setUpdateTime(LocalDateTime.now());
         return item;
     }
 

--- a/src/test/java/com/catveloper365/studyshop/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/catveloper365/studyshop/repository/ItemRepositoryTest.java
@@ -51,8 +51,6 @@ class ItemRepositoryTest {
         if(itemSellStatus.equals(ItemSellStatus.SOLD_OUT)){
             item.setStockNumber(0);
         }
-        item.setRegTime(LocalDateTime.now());
-        item.setUpdateTime(LocalDateTime.now());
 //        System.out.println(item);
         return item;
     }


### PR DESCRIPTION
### 연관 이슈 관리
Closes: #32 

### 교재와 다르게 실습한 부분
1. BaseTimeEntity와 BaseEntity의 `@Setter` 어노테이션 사용 여부
    - 교재 : BaseTimeEntity에는 `@Setter`를 사용하고, BaseEntity에는 사용하지 않음
    - 나 : 둘다 `@Setter` 어노테이션을 사용하지 않음
    - 자세한 내용은 #32 의 진행 중 이슈 2번 참고

2. Auditing 기능 테스트
    - 교재 : 회원 엔티티를 저장할 때 등록 시간, 수정 시간, 등록자, 수정자 값이 자동으로 입력되는 지 출력해봄
    - 나
      - AssertJ의 Assertions를 사용하여 검증 코드까지 작성
      - 수정할 때도 Auditing 기능에 의해 수정 시간이 변경되는 지 테스트
    - 테스트 코드를 통해 BaseTimeEntity에 `@Setter` 어노테이션이 필요 없음을 검증