### PR TITLE
Part6-3. 상품 관리하기 실습

### DIFF
--- a/src/main/java/com/catveloper365/studyshop/controller/ItemController.java
+++ b/src/main/java/com/catveloper365/studyshop/controller/ItemController.java
@@ -1,8 +1,13 @@
 package com.catveloper365.studyshop.controller;
 
 import com.catveloper365.studyshop.dto.ItemFormDto;
+import com.catveloper365.studyshop.dto.ItemSearchDto;
+import com.catveloper365.studyshop.entity.Item;
 import com.catveloper365.studyshop.service.ItemService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -15,6 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 import javax.persistence.EntityNotFoundException;
 import javax.validation.Valid;
 import java.util.List;
+import java.util.Optional;
 
 @Controller
 @RequiredArgsConstructor
@@ -90,5 +96,18 @@ public class ItemController {
             return "item/itemForm";
         }
         return "redirect:/";
+    }
+
+    /** 상품 관리 페이지 이동 */
+    @GetMapping(value = {"/admin/items", "/admin/items/{page}"})
+    public String i(ItemSearchDto itemSearchDto,
+                             @PathVariable("page") Optional<Integer> page, Model model) {
+        Pageable pageable = PageRequest.of(page.isPresent() ? page.get() : 0, 3);
+
+        Page<Item> items = itemService.getAdminItemPage(itemSearchDto, pageable);
+        model.addAttribute("items", items);
+        model.addAttribute("itemSearchDto", itemSearchDto);
+        model.addAttribute("maxPage", 5);
+        return "item/itemMng";
     }
 }

--- a/src/main/java/com/catveloper365/studyshop/dto/ItemSearchDto.java
+++ b/src/main/java/com/catveloper365/studyshop/dto/ItemSearchDto.java
@@ -1,0 +1,17 @@
+package com.catveloper365.studyshop.dto;
+
+import com.catveloper365.studyshop.constant.ItemSellStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class ItemSearchDto {
+    private ItemSellStatus searchSellStatus; //상품 판매 상태
+
+    //지정한 조건 이후로 등록된 상품 조회(all, 1d, 1w, 1m, 6m)
+    private String searchDateType; //상품 등록 기간
+
+    private String searchBy; //상품 조회 유형(itemNm, createdBy)
+
+    private String searchQuery = ""; //조회 유형에 대한 검색어
+}

--- a/src/main/java/com/catveloper365/studyshop/repository/ItemRepository.java
+++ b/src/main/java/com/catveloper365/studyshop/repository/ItemRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface ItemRepository extends JpaRepository<Item, Long>,
-        QuerydslPredicateExecutor<Item> {
+        QuerydslPredicateExecutor<Item>, ItemRepositoryCustom {
 
     List<Item> findByItemNm(String itemNm); //상품명으로 조회
 

--- a/src/main/java/com/catveloper365/studyshop/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/catveloper365/studyshop/repository/ItemRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.catveloper365.studyshop.repository;
+
+import com.catveloper365.studyshop.dto.ItemSearchDto;
+import com.catveloper365.studyshop.entity.Item;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ItemRepositoryCustom {
+    Page<Item> getAdminItemPage(ItemSearchDto itemSearchDto, Pageable pageable);
+}

--- a/src/main/java/com/catveloper365/studyshop/repository/ItemRepositoryCustomImpl.java
+++ b/src/main/java/com/catveloper365/studyshop/repository/ItemRepositoryCustomImpl.java
@@ -1,0 +1,81 @@
+package com.catveloper365.studyshop.repository;
+
+import com.catveloper365.studyshop.constant.ItemSellStatus;
+import com.catveloper365.studyshop.dto.ItemSearchDto;
+import com.catveloper365.studyshop.entity.Item;
+import com.catveloper365.studyshop.entity.QItem;
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.thymeleaf.util.StringUtils;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
+    private JPAQueryFactory queryFactory;
+
+    public ItemRepositoryCustomImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    private BooleanExpression searchSellStatusEq(ItemSellStatus searchSellStatus) {
+        return searchSellStatus == null ? null : QItem.item.itemSellStatus.eq(searchSellStatus);
+    }
+
+    private BooleanExpression regDtsAfter(String searchDateType) {
+        LocalDateTime dateTime = LocalDateTime.now();
+
+        if (StringUtils.equals("all", searchDateType) || searchDateType == null) {
+            return null;
+        } else if (StringUtils.equals("1d", searchDateType)) {
+            dateTime = dateTime.minusDays(1);
+        } else if (StringUtils.equals("1w", searchDateType)) {
+            dateTime = dateTime.minusWeeks(1);
+        } else if (StringUtils.equals("1m", searchDateType)) {
+            dateTime = dateTime.minusMonths(1);
+        } else if (StringUtils.equals("6m", searchDateType)) {
+            dateTime = dateTime.minusMonths(6);
+        }
+        return QItem.item.regTime.after(dateTime);
+    }
+
+    private BooleanExpression searchByLike(String searchBy, String searchQuery) {
+        if (StringUtils.equals("itemNm", searchBy)) {
+            return QItem.item.itemNm.like("%" + searchQuery + "%");
+        } else if (StringUtils.equals("createdBy", searchBy)) {
+            return QItem.item.createdBy.like("%" + searchQuery + "%");
+        }
+        return null;
+    }
+
+    @Override
+    public Page<Item> getAdminItemPage(ItemSearchDto itemSearchDto, Pageable pageable) {
+        //상품 데이터 리스트 조회
+        List<Item> content = queryFactory.selectFrom(QItem.item)
+                .where(regDtsAfter(itemSearchDto.getSearchDateType()),
+                        searchSellStatusEq(itemSearchDto.getSearchSellStatus()),
+                        searchByLike(itemSearchDto.getSearchBy(),
+                                itemSearchDto.getSearchQuery()))
+                .orderBy(QItem.item.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        //상품 데이터 전체 개수 조회
+        Long total = queryFactory.select(Wildcard.count).from(QItem.item)
+                .where(regDtsAfter(itemSearchDto.getSearchDateType()),
+                        searchSellStatusEq(itemSearchDto.getSearchSellStatus()),
+                        searchByLike(itemSearchDto.getSearchBy(),
+                                itemSearchDto.getSearchQuery()))
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+}

--- a/src/main/java/com/catveloper365/studyshop/service/ItemService.java
+++ b/src/main/java/com/catveloper365/studyshop/service/ItemService.java
@@ -2,11 +2,14 @@ package com.catveloper365.studyshop.service;
 
 import com.catveloper365.studyshop.dto.ItemFormDto;
 import com.catveloper365.studyshop.dto.ItemImgDto;
+import com.catveloper365.studyshop.dto.ItemSearchDto;
 import com.catveloper365.studyshop.entity.Item;
 import com.catveloper365.studyshop.entity.ItemImg;
 import com.catveloper365.studyshop.repository.ItemImgRepository;
 import com.catveloper365.studyshop.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -79,5 +82,11 @@ public class ItemService {
         }
 
         return item.getId();
+    }
+
+    /** 상품 관리 페이지 조회 */
+    @Transactional(readOnly = true)
+    public Page<Item> getAdminItemPage(ItemSearchDto itemSearchDto, Pageable pageable) {
+        return itemRepository.getAdminItemPage(itemSearchDto, pageable);
     }
 }

--- a/src/main/resources/templates/item/itemMng.html
+++ b/src/main/resources/templates/item/itemMng.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/layout1}">
+
+<!-- 사용자 스크립트 추가 -->
+<th:block layout:fragment="script">
+    <script th:inline="javascript">
+        $(document).ready(function(){
+            $("#searchBtn").on("click",function(e){
+                e.preventDefault();
+                page(0);
+            });
+        });
+
+        function page(page){
+            var searchDateType = $("#searchDateType").val();
+            var searchSellStatus = $("#searchSellStatus").val();
+            var searchBy = $("#searchBy").val();
+            var searchQuery = $("#searchQuery").val();
+
+            location.href="/admin/items/" + page + "?searchDateType=" + searchDateType
+            + "&searchSellStatus=" + searchSellStatus
+            + "&searchBy=" + searchBy
+            + "&searchQuery=" + searchQuery;
+        }
+    </script>
+</th:block>
+
+<!-- 사용자 CSS 추가 -->
+<th:block layout:fragment="css">
+    <style>
+        select{
+            margin-right:10px;
+        }
+    </style>
+</th:block>
+
+<div layout:fragment="content">
+    <form th:action="@{'/admin/items/' + ${items.number}}" role="form" method="get" th:object="${items}">
+        <table class="table">
+            <thead>
+            <tr>
+                <td>상품아이디</td>
+                <td>상품명</td>
+                <td>상태</td>
+                <td>등록자</td>
+                <td>등록일</td>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="item, status:${items.getContent()}">
+                <td th:text="${item.id}"></td>
+                <td>
+                    <a th:href="'/admin/item/' +${item.id}"
+                       th:text="${item.itemNm}"></a>
+                </td>
+                <td th:text="${item.itemSellStatus == T(com.catveloper365.studyshop.constant.ItemSellStatus).SELL} ? '판매중' : '품절'"></td>
+                <td th:text="${item.createdBy}"></td>
+                <td th:text="${item.regTime}"></td>
+            </tr>
+            </tbody>
+        </table>
+
+        <!-- pagination -->
+        <div th:with="start=${(items.number/maxPage)*maxPage + 1},
+        end=(${(items.totalPages == 0) ? 1 : (start + (maxPage - 1)
+        < items.totalPages ? start + (maxPage - 1) : items.totalPages)})">
+            <ul class="pagination justify-content-center">
+                <li class="page-item" th:classappend="${items.first}?'disabled'">
+                    <a th:onclick="'javascript:page(' + ${items.number - 1} + ')'" aria-label='Previous' class="page-link">
+                        <span aria-hidden='true'>Previous</span>
+                    </a>
+                </li>
+                <li class="page-item" th:each="page: ${#numbers.sequence(start,end)}" th:classappend="${items.number eq page-1}?'active':''">
+                    <a th:onclick="'javascript:page(' + ${page - 1} + ')'" th:inline="text" class="page-link">[[${page}]]</a>
+                </li>
+                <li class="page-item" th:classappend="${items.last}?'disabled'">
+                    <a th:onclick="'javascript:page(' + ${items.number + 1} + ')'" aria-label='Next' class="page-link">
+                        <span aria-hidden='true'>Next</span>
+                    </a>
+                </li>
+            </ul>
+        </div>
+
+        <div class="d-flex justify-content-center" th:object="${itemSearchDto}">
+            <select th:field="*{searchDateType}" class="form-control w-auto">
+                <option value="all">전체기간</option>
+                <option value="1d">1일</option>
+                <option value="1w">1주</option>
+                <option value="1m">1개월</option>
+                <option value="6m">6개월</option>
+            </select>
+            <select th:field="*{searchSellStatus}" class="form-control w-auto">
+                <option value="">판매상태(전체)</option>
+                <option value="SELL">판매</option>
+                <option value="SOLD_OUT">품절</option>
+            </select>
+            <select th:field="*{searchBy}" class="form-control w-auto">
+                <option value="itemNm">상품명</option>
+                <option value="createdBy">등록자</option>
+            </select>
+            <input th:field="*{searchQuery}" type="text" class="form-control w-auto" placeholder="검색어를 입력해주세요">
+            <button id="searchBtn" type="submit" class="btn btn-primary">검색</button>
+        </div>
+
+    </form>
+</div>
+
+</html>


### PR DESCRIPTION
### 연관 이슈 관리
Closes: #38 

### 교재와 다르게 실습한 부분
1. 부트스트랩의 최신 버전 사용
    - 교재는 4.5.2 버전 사용, 나는 5.3.1 버전 사용
    - 상품 관리 페이지의 검색 조건을 한 줄로 표현하는 방법이 달라져서 블로그, 공식 문서 참고하여 작성
    - [참고 블로그](https://blog.naver.com/yht415/222494903371) [공식 사이트 참고](https://getbootstrap.kr/docs/5.0/utilities/flex/)

2. Querydsl 버전 업에 의한 코드 변경
    - 교재에서는 deprecated된 메서드를 사용했기때문에 교재 공식 카페에서 제공해준 새로운 방법으로 사용자 정의 인터페이스 구현 코드 작성
    - [교재 공식 카페 공지사항 참고](https://cafe.naver.com/codefirst/582)