### PR TITLE
Part6-4. 메인 화면 실습

### DIFF
--- a/src/main/java/com/catveloper365/studyshop/controller/ItemController.java
+++ b/src/main/java/com/catveloper365/studyshop/controller/ItemController.java
@@ -100,7 +100,7 @@ public class ItemController {
 
     /** 상품 관리 페이지 이동 */
     @GetMapping(value = {"/admin/items", "/admin/items/{page}"})
-    public String i(ItemSearchDto itemSearchDto,
+    public String itemManage(ItemSearchDto itemSearchDto,
                              @PathVariable("page") Optional<Integer> page, Model model) {
         Pageable pageable = PageRequest.of(page.isPresent() ? page.get() : 0, 3);
 

--- a/src/main/java/com/catveloper365/studyshop/controller/MainController.java
+++ b/src/main/java/com/catveloper365/studyshop/controller/MainController.java
@@ -1,12 +1,32 @@
 package com.catveloper365.studyshop.controller;
 
+import com.catveloper365.studyshop.dto.ItemSearchDto;
+import com.catveloper365.studyshop.dto.MainItemDto;
+import com.catveloper365.studyshop.service.ItemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import java.util.Optional;
+
 @Controller
+@RequiredArgsConstructor
 public class MainController {
+
+    private final ItemService itemService;
+
     @GetMapping("/")
-    public String main() {
+    public String main(ItemSearchDto itemSearchDto, Optional<Integer> page, Model model) {
+        Pageable pageable = PageRequest.of(page.isPresent() ? page.get() : 0, 6);
+        Page<MainItemDto> items = itemService.getMainItemPage(itemSearchDto, pageable);
+        model.addAttribute("items", items);
+        model.addAttribute("itemSearchDto", itemSearchDto);
+        model.addAttribute("maxPage", 5);
+
         return "main";
     }
 }

--- a/src/main/java/com/catveloper365/studyshop/dto/MainItemDto.java
+++ b/src/main/java/com/catveloper365/studyshop/dto/MainItemDto.java
@@ -1,0 +1,27 @@
+package com.catveloper365.studyshop.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class MainItemDto {
+    private Long id;
+
+    private String itemNm;
+
+    private String itemDetail;
+
+    private String imgUrl;
+
+    private Integer price;
+
+    @QueryProjection
+    public MainItemDto(Long id, String itemNm, String itemDetail, String imgUrl, Integer price) {
+        this.id = id;
+        this.itemNm = itemNm;
+        this.itemDetail = itemDetail;
+        this.imgUrl = imgUrl;
+        this.price = price;
+    }
+}

--- a/src/main/java/com/catveloper365/studyshop/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/catveloper365/studyshop/repository/ItemRepositoryCustom.java
@@ -1,10 +1,14 @@
 package com.catveloper365.studyshop.repository;
 
 import com.catveloper365.studyshop.dto.ItemSearchDto;
+import com.catveloper365.studyshop.dto.MainItemDto;
 import com.catveloper365.studyshop.entity.Item;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ItemRepositoryCustom {
     Page<Item> getAdminItemPage(ItemSearchDto itemSearchDto, Pageable pageable);
+
+    Page<MainItemDto> getMainItemPage(ItemSearchDto itemSearchDto, Pageable pageable);
+
 }

--- a/src/main/java/com/catveloper365/studyshop/repository/ItemRepositoryCustomImpl.java
+++ b/src/main/java/com/catveloper365/studyshop/repository/ItemRepositoryCustomImpl.java
@@ -2,8 +2,11 @@ package com.catveloper365.studyshop.repository;
 
 import com.catveloper365.studyshop.constant.ItemSellStatus;
 import com.catveloper365.studyshop.dto.ItemSearchDto;
+import com.catveloper365.studyshop.dto.MainItemDto;
+import com.catveloper365.studyshop.dto.QMainItemDto;
 import com.catveloper365.studyshop.entity.Item;
 import com.catveloper365.studyshop.entity.QItem;
+import com.catveloper365.studyshop.entity.QItemImg;
 import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Wildcard;
@@ -76,6 +79,43 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total);
+    }
+
+    private BooleanExpression itemNmLike(String searchQuery) {
+        return StringUtils.isEmpty(searchQuery) ? null : QItem.item.itemNm.like("%" + searchQuery + "%");
+    }
+
+    @Override
+    public Page<MainItemDto> getMainItemPage(ItemSearchDto itemSearchDto, Pageable pageable) {
+        QItem item = QItem.item;
+        QItemImg itemImg = QItemImg.itemImg;
+
+        List<MainItemDto> content = queryFactory
+                .select(
+                        new QMainItemDto(
+                                item.id,
+                                item.itemNm,
+                                item.itemDetail,
+                                itemImg.imgUrl,
+                                item.price)
+                ).from(itemImg)
+                .join(itemImg.item, item)
+                .where(itemImg.repImgYn.eq("Y"))
+                .where(itemNmLike(itemSearchDto.getSearchQuery()))
+                .orderBy(item.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .select(Wildcard.count)
+                .from(itemImg)
+                .join(itemImg.item, item)
+                .where(itemImg.repImgYn.eq("Y"))
+                .where(itemNmLike(itemSearchDto.getSearchQuery()))
+                .fetchOne();
+
+        return new PageImpl<>(content,pageable,total);
     }
 
 }

--- a/src/main/java/com/catveloper365/studyshop/service/ItemService.java
+++ b/src/main/java/com/catveloper365/studyshop/service/ItemService.java
@@ -3,6 +3,7 @@ package com.catveloper365.studyshop.service;
 import com.catveloper365.studyshop.dto.ItemFormDto;
 import com.catveloper365.studyshop.dto.ItemImgDto;
 import com.catveloper365.studyshop.dto.ItemSearchDto;
+import com.catveloper365.studyshop.dto.MainItemDto;
 import com.catveloper365.studyshop.entity.Item;
 import com.catveloper365.studyshop.entity.ItemImg;
 import com.catveloper365.studyshop.repository.ItemImgRepository;
@@ -88,5 +89,11 @@ public class ItemService {
     @Transactional(readOnly = true)
     public Page<Item> getAdminItemPage(ItemSearchDto itemSearchDto, Pageable pageable) {
         return itemRepository.getAdminItemPage(itemSearchDto, pageable);
+    }
+
+    /** 메인 페이지 조회 */
+    @Transactional(readOnly = true)
+    public Page<MainItemDto> getMainItemPage(ItemSearchDto itemSearchDto, Pageable pageable) {
+        return itemRepository.getMainItemPage(itemSearchDto, pageable);
     }
 }

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -36,7 +36,7 @@
             </li>
           </ul>
           <form class="d-flex" role="search" th:action="@{/}" method="get">
-            <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
+            <input class="form-control me-2" type="search" name="searchQuery" placeholder="Search" aria-label="Search">
             <button class="btn btn-outline-success" type="submit">Search</button>
           </form>
         </div>

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -3,7 +3,110 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layouts/layout1}">
 
-  <div layout:fragment="content">
-     본문 영역입니다.
-  </div>
-</html>
+<!-- 사용자 CSS 추가 -->
+<th:block layout:fragment="css">
+    <style>
+        .carousel-inner > .item {
+            height: 350px;
+        }
+        .margin{
+            margin-bottom:30px;
+        }
+        .banner{
+            height: 300px;
+            position: absolute; top:0; left: 0;
+            width: 100%;
+            height: 100%;
+        }
+        .card-text{
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow: hidden;
+        }
+        a{
+            text-decoration:none;
+        }
+        a:hover{
+            text-decoration:underline;
+        }
+        .center{
+            text-align:center;
+        }
+    </style>
+</th:block>
+
+<div layout:fragment="content">
+
+    <!-- 슬라이드 배너 - 컨트롤,인디케이터 포함 -->
+    <div id="carouselExampleIndicators" class="carousel carousel-dark slide margin" data-bs-ride="carousel">
+        <div class="carousel-indicators">
+            <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
+            <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="1" aria-label="Slide 2"></button>
+        </div>
+        <div class="carousel-inner">
+            <div class="carousel-item active item">
+                <img class="d-block w-100 banner" src="https://user-images.githubusercontent.com/13268420/112147492-1ab76200-8c20-11eb-8649-3d2f282c3c02.png" alt="First slide">
+            </div>
+            <div class="carousel-item item">
+                <img class="d-block w-100 banner" src="https://github.com/catveloper365/study-book-boot-shop/assets/18108861/efb772b4-e2ae-411a-901d-3587bfc3d2db" alt="Second slide">
+
+            </div>
+        </div>
+        <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleDark" data-bs-slide="prev">
+            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+            <span class="visually-hidden">Previous</span>
+        </button>
+        <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide="next">
+            <span class="carousel-control-next-icon" aria-hidden="true"></span>
+            <span class="visually-hidden">Next</span>
+        </button>
+    </div>
+
+    <!-- 상품 검색 -->
+    <input type="hidden" name="searchQuery" th:value="${itemSearchDto.searchQuery}">
+    <div th:if="${not #strings.isEmpty(itemSearchDto.searchQuery)}" class="center">
+        <p class="h3 font-weight-bold" th:text="'검색어(' + ${itemSearchDto.searchQuery} + ')에 대한 검색 결과'"></p>
+    </div>
+
+    <!-- 상품 리스트 조회 -->
+    <div class="row">
+        <th:block th:each="item, status: ${items.getContent()}">
+            <div class="col-md-4 margin">
+                <div class="card">
+                    <a th:href="'/item/' +${item.id}" class="text-dark">
+                        <img th:src="${item.imgUrl}" class="card-img-top" th:alt="${item.itemNm}" height="200">
+                        <div class="card-body">
+                            <h4 class="card-title">[[${item.itemNm}]]</h4>
+                            <p class="card-text">[[${item.itemDetail}]]</p>
+                            <h3 class="card-title text-danger">[[${item.price}]]원</h3>
+                        </div>
+                    </a>
+                </div>
+            </div>
+        </th:block>
+    </div>
+
+    <!-- 페이지 네비게이션 -->
+    <div th:with="start=${(items.number/maxPage)*maxPage + 1}, end=(${(items.totalPages == 0) ? 1 : (start + (maxPage - 1) < items.totalPages ? start + (maxPage - 1) : items.totalPages)})" >
+        <ul class="pagination justify-content-center">
+
+            <li class="page-item" th:classappend="${items.number eq 0}?'disabled':''">
+                <a th:href="@{'/' + '?searchQuery=' + ${itemSearchDto.searchQuery} + '&page=' + ${items.number-1}}" aria-label='Previous' class="page-link">
+                    <span aria-hidden='true'>Previous</span>
+                </a>
+            </li>
+
+            <li class="page-item" th:each="page: ${#numbers.sequence(start, end)}" th:classappend="${items.number eq page-1}?'active':''">
+                <a th:href="@{'/' +'?searchQuery=' + ${itemSearchDto.searchQuery} + '&page=' + ${page-1}}" th:inline="text" class="page-link">[[${page}]]</a>
+            </li>
+
+            <li class="page-item" th:classappend="${items.number+1 ge items.totalPages}?'disabled':''">
+                <a th:href="@{'/' +'?searchQuery=' + ${itemSearchDto.searchQuery} + '&page=' + ${items.number+1}}" aria-label='Next' class="page-link">
+                    <span aria-hidden='true'>Next</span>
+                </a>
+            </li>
+
+        </ul>
+    </div>
+
+</div>


### PR DESCRIPTION
### 연관 이슈 관리
Closes: #40 

### 교재와 다르게 실습한 부분
1. 부트스트랩의 캐러셀 컴포넌트를 사용한 슬라이드 배너 기능 보완 [공식 사이트 참고](https://getbootstrap.kr/docs/5.0/components/carousel/)
    - 배너 이미지 1개 더 추가하여, 총 2개의 이미지가 슬라이드되어 보이도록 함
    - 배너 앞,뒤로 이동할 수 있는 컨트롤(<,>)과 인디케이터를 추가
    - 컨트롤과 인디케이터가 잘 보이도록 다크 스타일 적용

2. 상단 네비게이션 바를 통해 상품을 검색했을 때, 검색 결과 문구를 명확하게 보완
    - 교재 : 값검색 결과
    - 나 : 검색어(값)에 대한 검색 결과

3. 메인 페이지의 상품 이미지 크기를 400->200으로 변경

4. Querydsl 버전 업에 의한 코드 변경
    - 교재에서는 deprecated된 메서드를 사용했기때문에 교재 공식 카페에서 제공해준 새로운 방법으로 사용자 정의 인터페이스 구현 코드 작성
    - [교재 공식 카페 공지사항 참고](https://cafe.naver.com/codefirst/583)