### PR TITLE
Part6-5. 상품 상세 페이지 실습

### DIFF
--- a/src/main/java/com/catveloper365/studyshop/controller/ItemController.java
+++ b/src/main/java/com/catveloper365/studyshop/controller/ItemController.java
@@ -110,4 +110,12 @@ public class ItemController {
         model.addAttribute("maxPage", 5);
         return "item/itemMng";
     }
+
+    /** 상품 상세 페이지 이동 */
+    @GetMapping(value = "/item/{itemId}")
+    public String itemDtl(Model model, @PathVariable("itemId") Long itemId){
+        ItemFormDto itemFormDto = itemService.getItemDtl(itemId);
+        model.addAttribute("item", itemFormDto);
+        return "item/itemDtl";
+    }
 }

--- a/src/main/java/com/catveloper365/studyshop/dto/MainItemDto.java
+++ b/src/main/java/com/catveloper365/studyshop/dto/MainItemDto.java
@@ -1,5 +1,6 @@
 package com.catveloper365.studyshop.dto;
 
+import com.catveloper365.studyshop.constant.ItemSellStatus;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,12 +17,15 @@ public class MainItemDto {
 
     private Integer price;
 
+    private ItemSellStatus itemSellStatus;
+
     @QueryProjection
-    public MainItemDto(Long id, String itemNm, String itemDetail, String imgUrl, Integer price) {
+    public MainItemDto(Long id, String itemNm, String itemDetail, String imgUrl, Integer price, ItemSellStatus itemSellStatus) {
         this.id = id;
         this.itemNm = itemNm;
         this.itemDetail = itemDetail;
         this.imgUrl = imgUrl;
         this.price = price;
+        this.itemSellStatus = itemSellStatus;
     }
 }

--- a/src/main/java/com/catveloper365/studyshop/repository/ItemRepositoryCustomImpl.java
+++ b/src/main/java/com/catveloper365/studyshop/repository/ItemRepositoryCustomImpl.java
@@ -97,7 +97,8 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
                                 item.itemNm,
                                 item.itemDetail,
                                 itemImg.imgUrl,
-                                item.price)
+                                item.price,
+                                item.itemSellStatus)
                 ).from(itemImg)
                 .join(itemImg.item, item)
                 .where(itemImg.repImgYn.eq("Y"))

--- a/src/main/resources/templates/item/itemDtl.html
+++ b/src/main/resources/templates/item/itemDtl.html
@@ -100,7 +100,7 @@
         </div>
     </div>
 
-    <div class="p-5 mb-4 bg-light rounded-3 mgt-30">
+    <div class="p-2 mb-4 bg-light rounded-3 mgt-30">
         <div class="container-fluid py-5">
             <h4 class>상품 상세 설명</h4>
             <hr class="my-4">

--- a/src/main/resources/templates/item/itemDtl.html
+++ b/src/main/resources/templates/item/itemDtl.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/layout1}">
+<head>
+    <meta name="_csrf" th:content="${_csrf.token}"/>
+    <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
+</head>
+
+<!-- 사용자 스크립트 추가 -->
+<th:block layout:fragment="script">
+    <script th:inline="javascript">
+        $(document).ready(function(){
+            calculateTotalPrice();
+
+            $("#count").change(function(){
+                calculateTotalPrice();
+            });
+        });
+
+        function calculateTotalPrice(){
+            var count = $("#count").val();
+            var price = $("#price").val();
+            var totalPrice = price * count;
+            $("#totalPrice").html(totalPrice + '원');
+        }
+    </script>
+</th:block>
+
+<!-- 사용자 CSS 추가 -->
+<th:block layout:fragment="css">
+    <style>
+        .mgb-15{
+            margin-bottom:15px;
+        }
+        .mgt-30{
+            margin-top:30px;
+        }
+        .mgt-50{
+            margin-top:50px;
+        }
+        .repImgDiv{
+            margin-right:15px;
+            height:auto;
+            width:50%;
+        }
+        .repImg{
+            width:100%;
+            height:400px;
+        }
+        .wd50{
+            height:auto;
+            width:50%;
+        }
+    </style>
+</th:block>
+
+<div layout:fragment="content" style="margin-left:15%;margin-right:15%">
+    <input type="hidden" id="itemId" th:value="${item.id}">
+    <div class="d-flex">
+        <div class="repImgDiv">
+            <img th:src="${item.itemImgDtoList[0].imgUrl}" class="rounded repImg" th:alt="${item.itemNm}">
+        </div>
+        <div class="wd50">
+            <!-- 상품 판매 상태에 대한 배지 표시 -->
+            <span th:if="${item.itemSellStatus == T(com.catveloper365.studyshop.constant.ItemSellStatus).SELL}" class="badge bg-primary mgb-15">
+                판매중
+            </span>
+            <span th:unless="${item.itemSellStatus == T(com.catveloper365.studyshop.constant.ItemSellStatus).SELL}" class="badge bg-danger mgb-15">
+                품절
+            </span>
+            <div class="h4" th:text="${item.itemNm}"></div>
+            <hr class="my-4">
+
+            <div class="text-start">
+                <div class="h4 text-danger text-left">
+                    <input type="hidden" th:value="${item.price}" id="price" name="price">
+                    <span th:text="${item.price}"></span>원
+                </div>
+                <div class="input-group w-50">
+                    <div class="input-group-prepend">
+                        <span class="input-group-text">수량</span>
+                    </div>
+                    <input type="number" name="count" id="count" class="form-control" value="1" min="1">
+                </div>
+            </div>
+            <hr class="my-4">
+
+            <div class="text-end mgt-50">
+                <h5>결제 금액</h5>
+                <h3 name="totalPrice" id="totalPrice" class="font-weight-bold"></h3>
+            </div>
+            <div th:if="${item.itemSellStatus == T(com.catveloper365.studyshop.constant.ItemSellStatus).SELL}" class="text-end">
+                <button type="button" class="btn btn-light btn-outline-primary btn-lg">장바구니 담기</button>
+                <button type="button" class="btn btn-primary btn-lg">주문하기</button>
+            </div>
+            <div th:unless="${item.itemSellStatus == T(com.catveloper365.studyshop.constant.ItemSellStatus).SELL}" class="text-end">
+                <button type="button" class="btn btn-danger btn-lg">품절</button>
+            </div>
+        </div>
+    </div>
+
+    <div class="p-5 mb-4 bg-light rounded-3 mgt-30">
+        <div class="container-fluid py-5">
+            <h4 class>상품 상세 설명</h4>
+            <hr class="my-4">
+            <p class="lead" th:text="${item.itemDetail}"></p>
+        </div>
+    </div>
+
+    <div th:each="itemImg : ${item.itemImgDtoList}" class="text-center">
+        <img th:if="${not #strings.isEmpty(itemImg.imgUrl)}" th:src="${itemImg.imgUrl}" class="rounded mgb-15" width="700">
+    </div>
+</div>
+
+</html>

--- a/src/main/resources/templates/item/itemDtl.html
+++ b/src/main/resources/templates/item/itemDtl.html
@@ -73,7 +73,7 @@
             <hr class="my-4">
 
             <div class="text-start">
-                <div class="h4 text-danger text-left">
+                <div class="h4 text-danger">
                     <input type="hidden" th:value="${item.price}" id="price" name="price">
                     <span th:text="${item.price}"></span>원
                 </div>

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -77,6 +77,11 @@
                         <img th:src="${item.imgUrl}" class="card-img-top" th:alt="${item.itemNm}" height="200">
                         <div class="card-body">
                             <h4 class="card-title">[[${item.itemNm}]]</h4>
+                            <p class="card-text">
+                                <!-- 상품 판매 상태에 대한 배지 표시 -->
+                                <span th:if="${item.itemSellStatus == T(com.catveloper365.studyshop.constant.ItemSellStatus).SELL}" class="badge bg-primary">판매중</span>
+                                <span th:unless="${item.itemSellStatus == T(com.catveloper365.studyshop.constant.ItemSellStatus).SELL}" class="badge bg-danger">품절</span>
+                            </p>
                             <p class="card-text">[[${item.itemDetail}]]</p>
                             <h3 class="card-title text-danger">[[${item.price}]]원</h3>
                         </div>


### PR DESCRIPTION
### 연관 이슈 관리
Closes: #42 

### 교재와 다르게 실습한 부분
1. 상품 상세 페이지 관련 교재와 다르게 진행한 부분
    - 여백 비율과 이미지 크기를 교재와 달리 화면에 보기 좋게 수정함
    - 부트스트랩 버전 업에 의한 차이
    - 자세한 내용은 #42 의 진행 중 이슈 2번 참고

2. 상품 상세 페이지에서 사용한 badge 컴포넌트를 메인 페이지에도 적용해봄
    - 교재(#40 , #42 )에는 없는 내용인데 응용하여 적용해봄
    - 자세한 내용은 #42 의 진행 중 이슈 3번 참고






