### PR TITLE
Part7-1. 주문 기능 구현하기 실습

### DIFF
--- a/src/main/java/com/catveloper365/studyshop/controller/OrderController.java
+++ b/src/main/java/com/catveloper365/studyshop/controller/OrderController.java
@@ -1,0 +1,47 @@
+package com.catveloper365.studyshop.controller;
+
+import com.catveloper365.studyshop.dto.OrderDto;
+import com.catveloper365.studyshop.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.validation.Valid;
+import java.security.Principal;
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping(value = "/order")
+    public @ResponseBody ResponseEntity order(@RequestBody @Valid OrderDto orderDto,
+                                              BindingResult bindingResult, Principal principal) {
+        if (bindingResult.hasErrors()) {
+            StringBuilder sb = new StringBuilder();
+            List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+            for (FieldError fieldError : fieldErrors) {
+                sb.append(fieldError.getDefaultMessage());
+            }
+            return new ResponseEntity<String>(sb.toString(), HttpStatus.BAD_REQUEST);
+        }
+
+        String email = principal.getName();
+        Long orderId;
+        try {
+            orderId = orderService.order(orderDto, email);
+        } catch (Exception e) {
+            return new ResponseEntity<String>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+
+        return new ResponseEntity<Long>(orderId, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/catveloper365/studyshop/dto/OrderDto.java
+++ b/src/main/java/com/catveloper365/studyshop/dto/OrderDto.java
@@ -1,0 +1,18 @@
+package com.catveloper365.studyshop.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+@Getter @Setter
+public class OrderDto {
+    @NotNull(message = "상품 아이디는 필수 입력 값입니다.")
+    private Long itemId;
+
+    @Min(value = 1, message = "최소 주문 수량은 1개 입니다.")
+    @Max(value = 999, message = "최대 주문 수량은 999개 입니다.")
+    private int count;
+}

--- a/src/main/java/com/catveloper365/studyshop/entity/Item.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/Item.java
@@ -49,6 +49,8 @@ public class Item extends BaseEntity {
         int restStock = this.stockNumber - orderCount; //주문 후 남은 재고 수량
         if (restStock < 0) {
             throw new OutOfStockException("상품의 재고가 부족합니다. (현재 재고 수량: " + this.stockNumber + ")");
+        } else if (restStock == 0){ //재고가 모두 소진되면 품절 상태로 변경
+            this.itemSellStatus = ItemSellStatus.SOLD_OUT;
         }
         this.stockNumber = restStock;
     }

--- a/src/main/java/com/catveloper365/studyshop/entity/Item.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/Item.java
@@ -2,6 +2,7 @@ package com.catveloper365.studyshop.entity;
 
 import com.catveloper365.studyshop.constant.ItemSellStatus;
 import com.catveloper365.studyshop.dto.ItemFormDto;
+import com.catveloper365.studyshop.exception.OutOfStockException;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -42,5 +43,13 @@ public class Item extends BaseEntity {
         this.stockNumber = itemFormDto.getStockNumber();
         this.itemDetail = itemFormDto.getItemDetail();
         this.itemSellStatus = itemFormDto.getItemSellStatus();
+    }
+
+    public void removeStock(int orderCount) {
+        int restStock = this.stockNumber - orderCount; //주문 후 남은 재고 수량
+        if (restStock < 0) {
+            throw new OutOfStockException("상품의 재고가 부족합니다. (현재 재고 수량: " + this.stockNumber + ")");
+        }
+        this.stockNumber = restStock;
     }
 }

--- a/src/main/java/com/catveloper365/studyshop/entity/Order.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/Order.java
@@ -32,4 +32,29 @@ public class Order extends BaseEntity {
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL,
             orphanRemoval = true, fetch = FetchType.LAZY)
     private List<OrderItem> orderItems = new ArrayList<>();
+
+    public void addOrderItem(OrderItem orderItem) {
+        orderItems.add(orderItem);
+        orderItem.setOrder(this); //양방향 참조 관계
+    }
+
+    public static Order createOrder(Member member, List<OrderItem> orderItemList) {
+        Order order = new Order();
+        order.setMember(member);
+        for (OrderItem orderItem : orderItemList) {
+            order.addOrderItem(orderItem);
+        }
+        order.setOrderStatus(OrderStatus.ORDER);
+        order.setOrderDate(LocalDateTime.now());
+        return order;
+    }
+
+    /** 총 주문 금액 구하기 */
+    public int getTotalPrice() {
+        int totalPrice = 0;
+        for (OrderItem orderItem : orderItems) {
+            totalPrice += orderItem.getTotalPrice();
+        }
+        return totalPrice;
+    }
 }

--- a/src/main/java/com/catveloper365/studyshop/entity/OrderItem.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/OrderItem.java
@@ -29,4 +29,17 @@ public class OrderItem extends BaseEntity {
 
     private int count; //수량
 
+    public static OrderItem createOrderItem(Item item, int count) {
+        OrderItem orderItem = new OrderItem();
+        orderItem.setItem(item);
+        orderItem.setCount(count);
+        orderItem.setOrderPrice(item.getPrice());
+
+        item.removeStock(count); //재고 수량 감소
+        return orderItem;
+    }
+
+    public int getTotalPrice() {
+        return orderPrice * count;
+    }
 }

--- a/src/main/java/com/catveloper365/studyshop/exception/OutOfStockException.java
+++ b/src/main/java/com/catveloper365/studyshop/exception/OutOfStockException.java
@@ -1,0 +1,8 @@
+package com.catveloper365.studyshop.exception;
+
+public class OutOfStockException extends RuntimeException{
+
+    public OutOfStockException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/catveloper365/studyshop/service/OrderService.java
+++ b/src/main/java/com/catveloper365/studyshop/service/OrderService.java
@@ -1,0 +1,44 @@
+package com.catveloper365.studyshop.service;
+
+import com.catveloper365.studyshop.dto.OrderDto;
+import com.catveloper365.studyshop.entity.Item;
+import com.catveloper365.studyshop.entity.Member;
+import com.catveloper365.studyshop.entity.Order;
+import com.catveloper365.studyshop.entity.OrderItem;
+import com.catveloper365.studyshop.repository.ItemRepository;
+import com.catveloper365.studyshop.repository.MemberRepository;
+import com.catveloper365.studyshop.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OrderService {
+    private final ItemRepository itemRepository;
+    private final MemberRepository memberRepository;
+    private final OrderRepository orderRepository;
+
+    public Long order(OrderDto orderDto, String email) {
+        //주문 상품 정보 조회
+        Item item = itemRepository.findById(orderDto.getItemId())
+                .orElseThrow(EntityNotFoundException::new);
+        //회원 정보 조회
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(EntityNotFoundException::new);
+
+        List<OrderItem> orderItemList = new ArrayList<>();
+        OrderItem orderItem = OrderItem.createOrderItem(item, orderDto.getCount());
+        orderItemList.add(orderItem);
+
+        Order order = Order.createOrder(member, orderItemList);
+        orderRepository.save(order);
+
+        return order.getId();
+    }
+}

--- a/src/main/resources/templates/item/itemDtl.html
+++ b/src/main/resources/templates/item/itemDtl.html
@@ -24,6 +24,44 @@
             var totalPrice = price * count;
             $("#totalPrice").html(totalPrice + '원');
         }
+
+        function order(){
+            var token = $("meta[name='_csrf']").attr("content");
+            var header = $("meta[name='_csrf_header']").attr("content");
+
+            var url = "/order";
+            var paramData = {
+                itemId : $("#itemId").val(),
+                count : $("#count").val()
+            };
+
+            var param = JSON.stringify(paramData);
+
+            $.ajax({
+                url : url,
+                type : "POST",
+                contentType : "application/json",
+                data : param,
+                beforeSend : function(xhr){
+                    /* 데이터를 전송하기 전에 헤더에 csrf 값을 설정 */
+                    xhr.setRequestHeader(header, token);
+                },
+                dataType : "json",
+                cache : false,
+                success : function(result, status){
+                    alert("주문이 완료 되었습니다.");
+                    location.href='/';
+                },
+                error : function(jqXHR, status, error){
+                    if(jqXHR.status == '401'){
+                        alert("로그인 후 이용해주세요");
+                        location.href='/members/login';
+                    } else{
+                        alert(jqXHR.responseText);
+                    }
+                }
+            });
+        }
     </script>
 </th:block>
 
@@ -92,7 +130,7 @@
             </div>
             <div th:if="${item.itemSellStatus == T(com.catveloper365.studyshop.constant.ItemSellStatus).SELL}" class="text-end">
                 <button type="button" class="btn btn-light btn-outline-primary btn-lg">장바구니 담기</button>
-                <button type="button" class="btn btn-primary btn-lg">주문하기</button>
+                <button type="button" class="btn btn-primary btn-lg" onclick="order()">주문하기</button>
             </div>
             <div th:unless="${item.itemSellStatus == T(com.catveloper365.studyshop.constant.ItemSellStatus).SELL}" class="text-end">
                 <button type="button" class="btn btn-danger btn-lg">품절</button>

--- a/src/test/java/com/catveloper365/studyshop/service/OrderServiceTest.java
+++ b/src/test/java/com/catveloper365/studyshop/service/OrderServiceTest.java
@@ -1,0 +1,74 @@
+package com.catveloper365.studyshop.service;
+
+import com.catveloper365.studyshop.constant.ItemSellStatus;
+import com.catveloper365.studyshop.dto.OrderDto;
+import com.catveloper365.studyshop.entity.Item;
+import com.catveloper365.studyshop.entity.Member;
+import com.catveloper365.studyshop.entity.Order;
+import com.catveloper365.studyshop.entity.OrderItem;
+import com.catveloper365.studyshop.repository.ItemRepository;
+import com.catveloper365.studyshop.repository.MemberRepository;
+import com.catveloper365.studyshop.repository.OrderRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class OrderServiceTest {
+
+    @Autowired private OrderService orderService;
+
+    @Autowired private OrderRepository orderRepository;
+
+    @Autowired private ItemRepository itemRepository;
+
+    @Autowired private MemberRepository memberRepository;
+
+    public Item saveItem() {
+        Item item = new Item();
+        item.setItemNm("테스트 상품");
+        item.setPrice(10000);
+        item.setItemDetail("테스트 상품 상세 설명");
+        item.setItemSellStatus(ItemSellStatus.SELL);
+        item.setStockNumber(100);
+        return itemRepository.save(item);
+    }
+
+    public Member saveMember() {
+        Member member = new Member();
+        member.setEmail("test@test.com");
+        return memberRepository.save(member);
+    }
+
+    @Test
+    @DisplayName("주문 테스트")
+    public void order() {
+        //given
+        Item item = saveItem(); //상품 등록
+        Member member = saveMember(); //회원가입
+
+        //주문 정보
+        OrderDto orderDto = new OrderDto();
+        orderDto.setCount(10);
+        orderDto.setItemId(item.getId());
+
+        //when
+        Long orderId = orderService.order(orderDto, member.getEmail());
+
+        //then
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(EntityNotFoundException::new);
+//        List<OrderItem> orderItems = order.getOrderItems();
+        int totalPrice = orderDto.getCount() * item.getPrice();
+        assertEquals(totalPrice, order.getTotalPrice());
+    }
+}


### PR DESCRIPTION
### 연관 이슈 관리
Closes: #44 

### 교재와 다르게 실습한 부분
1. 주문으로 인해 재고가 0이 되었을 때, 상품 판매 상태를 품절(SOLD_OUT)으로 자동 변경되도록 로직 추가  
    - 자세한 사항은 #44 진행 중 이슈 2번 참고

2. 주문 기능에 대한 테스트 클래스 OrderServiceTest에 `재고 부족, 품절` 테스트 케이스 추가
    - 코드의 재사용성을 고려하여 주문 정보 OrderDto를 생성하는 부분을 **별도의 메서드** createOrderDto로 분리하여 사용
    - 정상적으로 처리되는 주문 테스트에 **검증 케이스** 추가 작성
      - 교재 : 총 주문 금액을 통해 검증 (OrderDto를 통해 계산한 총 주문 금액 == DB에서 조회한 Order 엔티티의 총 주문 금액)
      - 내가 추가한 검증 케이스 : 주문 수량만큼 **재고 수량이 감소**했는 지 검증
    - **재고가 부족**하여 예외 상황이 발생하는 경우에 대한 테스트 케이스 추가
    - 개인적으로 추가한 **품절** (주문으로 인해 재고가 0이 되었을 때) 기능에 대한 테스트 케이스 추가
    - `given, when, then` 테스트 패턴 사용