### PR TITLE
Part7-3. 주문 취소하기 실습

### DIFF
--- a/src/main/java/com/catveloper365/studyshop/controller/OrderController.java
+++ b/src/main/java/com/catveloper365/studyshop/controller/OrderController.java
@@ -63,4 +63,16 @@ public class OrderController {
         model.addAttribute("maxPage", 5);
         return "order/orderHist";
     }
+
+    /** 주문 취소 처리 요청 */
+    @PostMapping("/order/{orderId}/cancel")
+    public @ResponseBody ResponseEntity cancelOrder(@PathVariable("orderId") Long orderId, Principal principal) {
+        //주문 취소 권한 검사
+        if (!orderService.validateOrder(orderId, principal.getName())) {
+            return new ResponseEntity<String>("주문 취소 권한이 없습니다.", HttpStatus.FORBIDDEN);
+        }
+
+        orderService.cancelOrder(orderId);
+        return new ResponseEntity<Long>(orderId, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/catveloper365/studyshop/entity/Item.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/Item.java
@@ -6,6 +6,7 @@ import com.catveloper365.studyshop.exception.OutOfStockException;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.thymeleaf.util.StringUtils;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -37,6 +38,7 @@ public class Item extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ItemSellStatus itemSellStatus; //상품 판매 상태
 
+    /** 상품 정보 수정 */
     public void updateItem(ItemFormDto itemFormDto) {
         this.itemNm = itemFormDto.getItemNm();
         this.price = itemFormDto.getPrice();
@@ -45,6 +47,7 @@ public class Item extends BaseEntity {
         this.itemSellStatus = itemFormDto.getItemSellStatus();
     }
 
+    /** 주문 수량 만큼 재고 감소 */
     public void removeStock(int orderCount) {
         int restStock = this.stockNumber - orderCount; //주문 후 남은 재고 수량
         if (restStock < 0) {
@@ -53,5 +56,16 @@ public class Item extends BaseEntity {
             this.itemSellStatus = ItemSellStatus.SOLD_OUT;
         }
         this.stockNumber = restStock;
+    }
+
+    /** 주문 수량 만큼 재고 증가 */
+    public void addStock(int orderCount) {
+        this.stockNumber += orderCount;
+
+        //품절이었던 상품의 재고가 증가하면 상품 판매 상태를 판매중으로 변경
+        if (StringUtils.equals(this.itemSellStatus, ItemSellStatus.SOLD_OUT)
+                && this.stockNumber > 0) {
+            this.itemSellStatus = ItemSellStatus.SELL;
+        }
     }
 }

--- a/src/main/java/com/catveloper365/studyshop/entity/Order.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/Order.java
@@ -57,4 +57,13 @@ public class Order extends BaseEntity {
         }
         return totalPrice;
     }
+
+    /** 주문 취소 */
+    public void cancelOrder() {
+        this.orderStatus = OrderStatus.CANCEL;
+
+        for (OrderItem orderItem : orderItems) {
+            orderItem.cancel();
+        }
+    }
 }

--- a/src/main/java/com/catveloper365/studyshop/entity/OrderItem.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/OrderItem.java
@@ -42,4 +42,9 @@ public class OrderItem extends BaseEntity {
     public int getTotalPrice() {
         return orderPrice * count;
     }
+
+    /** 주문 취소 시 재고 수량 복구 */
+    public void cancel() {
+        this.getItem().addStock(count);
+    }
 }

--- a/src/main/resources/templates/order/orderHist.html
+++ b/src/main/resources/templates/order/orderHist.html
@@ -7,6 +7,47 @@
     <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
 </head>
 
+<!-- 사용자 스크립트 추가 -->
+<th:block layout:fragment="script">
+    <script th:inline="javascript">
+        function cancelOrder(orderId){
+            var token = $("meta[name='_csrf']").attr("content");
+            var header = $("meta[name='_csrf_header']").attr("content");
+
+            var url = "/order/" + orderId + "/cancel";
+            var paramData = {
+                orderId : orderId,
+            };
+
+            var param = JSON.stringify(paramData);
+            $.ajax({
+                url : url,
+                type : "POST",
+                contentType : "application/json",
+                data : param,
+                beforeSend : function(xhr){
+                    /* 데이터를 전송하기 전에 헤더에 csrf 값을 설정 */
+                    xhr.setRequestHeader(header, token);
+                },
+                dataType : "json",
+                cache : false,
+                success : function(result, status){
+                    alert("주문이 취소 되었습니다.");
+                    location.href='/orders/' + [[${page}]];
+                },
+                error : function(jqXHR, status, error){
+                    if(jqXHR.status == '401'){
+                        alert("로그인 후 이용해주세요.");
+                        location.href='/members/login';
+                    } else{
+                        alert(jqXHR.responseText);
+                    }
+                }
+            });
+        }
+    </script>
+</th:block>
+
 <!-- 사용자 CSS 추가 -->
 <th:block layout:fragment="css">
     <style>
@@ -49,7 +90,7 @@
             <h4 th:text="${order.orderDate} + ' 주문'"></h4>
             <div class="ml-3">
                 <th:block th:if="${order.orderStatus == T(com.catveloper365.studyshop.constant.OrderStatus).ORDER}">
-                    <button type="button" class="btn btn-outline-secondary" th:value="${order.orderId}" style=" margin-left:10px">주문 취소</button>
+                    <button type="button" class="btn btn-outline-secondary" th:value="${order.orderId}" style=" margin-left:10px" onclick="cancelOrder(this.value)">주문 취소</button>
                 </th:block>
                 <th:block th:unless="${order.orderStatus == T(com.catveloper365.studyshop.constant.OrderStatus).ORDER}">
                     <h4 style="margin-left:10px">(취소 완료)</h4>


### PR DESCRIPTION
### 연관 이슈 관리
Closes: #48 

### 교재와 다르게 실습한 부분
1. 재고가 0이어서 품절 상태인 상품에 대한 주문을 취소했을 때, 상품 판매 상태를 다시 판매중(SELL)으로 자동 변경되도록 로직 추가  
    - 자세한 사항은 #48  진행 중 이슈 2번 참고

2. 주문 관련 기능 테스트를 위한 OrderService 테스트 클래스에 검증 케이스 추가 
    - 개인적으로 추가한 기능(품절 상품 주문 취소 시, 다시 판매중으로 변경)에 대한 검증 케이스 추가
      - 이를 위해서 100개 중 10개를 주문했다가 취소하는 교재와 다르게, 100개 중 100개를 주문했다가 취소하도록 함
    - 정상적으로 처리되는 주문 테스트에 **검증 케이스** 추가 작성
      - 새로 추가한 검증 케이스 : 주문 후의 주문 상태는 OrderStatus.ORDER여야한다

3. 상품의 재고 수량을 증가시키는 addStock 메서드의 매개변수명을 다르게 지정
    - 교재 : stockNumber
    - 나 : orderCount
    - removeStock 구현 시에도 교재(stockNumber)와 달리 orderCount라고 명명했고, addStock도 동일하게 orderCount라고 명명함
    - 이유 : 교재와 같이 명명하는게 표준 방법인 것 같은데, orderCount라고 했을 때 의미가 더 명확해진다고 생각함