### PR TITLE
Part8-1. 장바구니 담기 실습

### DIFF
--- a/src/main/java/com/catveloper365/studyshop/controller/CartController.java
+++ b/src/main/java/com/catveloper365/studyshop/controller/CartController.java
@@ -1,0 +1,48 @@
+package com.catveloper365.studyshop.controller;
+
+import com.catveloper365.studyshop.dto.CartItemDto;
+import com.catveloper365.studyshop.service.CartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.validation.Valid;
+import java.security.Principal;
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class CartController {
+
+    private final CartService cartService;
+
+    @PostMapping(value = "/cart")
+    public @ResponseBody ResponseEntity order(@RequestBody @Valid CartItemDto cartItemDto,
+                                              BindingResult bindingResult, Principal principal) {
+        if (bindingResult.hasErrors()) {
+            StringBuilder sb = new StringBuilder();
+            List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+            for (FieldError fieldError : fieldErrors) {
+                sb.append(fieldError.getDefaultMessage());
+            }
+            return new ResponseEntity<String>(sb.toString(), HttpStatus.BAD_REQUEST);
+        }
+
+        String email = principal.getName();
+        Long cartItemId;
+
+        try {
+            cartItemId = cartService.addCart(cartItemDto, email);
+        } catch (Exception e) {
+            return new ResponseEntity<String>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+
+        return new ResponseEntity<Long>(cartItemId, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/catveloper365/studyshop/dto/CartItemDto.java
+++ b/src/main/java/com/catveloper365/studyshop/dto/CartItemDto.java
@@ -1,0 +1,18 @@
+package com.catveloper365.studyshop.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+public class CartItemDto {
+
+    @NotNull(message = "상품 아이디는 필수 입력 값 입니다.")
+    private Long itemId;
+    
+    @Min(value = 1, message = "최소 1개 이상 담아주세요.")
+    private int count;
+}

--- a/src/main/java/com/catveloper365/studyshop/entity/Cart.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/Cart.java
@@ -21,4 +21,10 @@ public class Cart extends BaseEntity{
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    public static Cart createCart(Member member) {
+        Cart cart = new Cart();
+        cart.setMember(member);
+        return cart;
+    }
 }

--- a/src/main/java/com/catveloper365/studyshop/entity/CartItem.java
+++ b/src/main/java/com/catveloper365/studyshop/entity/CartItem.java
@@ -25,4 +25,16 @@ public class CartItem extends BaseEntity {
     private Item item;
 
     private int count;
+
+    public static CartItem createCartItem(Cart cart, Item item, int count) {
+        CartItem cartItem = new CartItem();
+        cartItem.setCart(cart);
+        cartItem.setItem(item);
+        cartItem.setCount(count);
+        return cartItem;
+    }
+
+    public void addCount(int count) {
+        this.count += count;
+    }
 }

--- a/src/main/java/com/catveloper365/studyshop/repository/CartItemRepository.java
+++ b/src/main/java/com/catveloper365/studyshop/repository/CartItemRepository.java
@@ -1,0 +1,11 @@
+package com.catveloper365.studyshop.repository;
+
+import com.catveloper365.studyshop.entity.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+
+    Optional<CartItem> findByCartIdAndItemId(Long cartId, Long itemId);
+}

--- a/src/main/java/com/catveloper365/studyshop/repository/CartRepository.java
+++ b/src/main/java/com/catveloper365/studyshop/repository/CartRepository.java
@@ -3,5 +3,9 @@ package com.catveloper365.studyshop.repository;
 import com.catveloper365.studyshop.entity.Cart;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CartRepository extends JpaRepository<Cart, Long> {
+
+    Optional<Cart> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/catveloper365/studyshop/service/CartService.java
+++ b/src/main/java/com/catveloper365/studyshop/service/CartService.java
@@ -1,0 +1,49 @@
+package com.catveloper365.studyshop.service;
+
+import com.catveloper365.studyshop.dto.CartItemDto;
+import com.catveloper365.studyshop.entity.Cart;
+import com.catveloper365.studyshop.entity.CartItem;
+import com.catveloper365.studyshop.entity.Item;
+import com.catveloper365.studyshop.entity.Member;
+import com.catveloper365.studyshop.repository.CartItemRepository;
+import com.catveloper365.studyshop.repository.CartRepository;
+import com.catveloper365.studyshop.repository.ItemRepository;
+import com.catveloper365.studyshop.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CartService {
+    private final ItemRepository itemRepository;
+    private final MemberRepository memberRepository;
+    private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
+
+    /** 장바구니 담기 */
+    public Long addCart(CartItemDto cartItemDto, String email) {
+        Item item = itemRepository.findById(cartItemDto.getItemId())
+                .orElseThrow(EntityNotFoundException::new);
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(EntityNotFoundException::new);
+
+        //로그인한 회원의 장바구니 엔티티 조회
+        Cart cart = cartRepository.findByMemberId(member.getId())
+                .orElseGet(() -> cartRepository.save(Cart.createCart(member)));
+
+        Optional<CartItem> savedCartItem = cartItemRepository.findByCartIdAndItemId(cart.getId(), item.getId());
+        if (savedCartItem.isPresent()) { //이미 장바구니에 있던 상품
+            savedCartItem.get().addCount(cartItemDto.getCount()); //장바구니에서 수량만 증가
+            return savedCartItem.get().getId();
+        } else { //장바구니에 없던 상품
+            CartItem cartItem = CartItem.createCartItem(cart, item, cartItemDto.getCount());
+            cartItemRepository.save(cartItem);
+            return cartItem.getId();
+        }
+    }
+}

--- a/src/main/resources/templates/item/itemDtl.html
+++ b/src/main/resources/templates/item/itemDtl.html
@@ -62,6 +62,44 @@
                 }
             });
         }
+
+        function addCart(){
+            var token = $("meta[name='_csrf']").attr("content");
+            var header = $("meta[name='_csrf_header']").attr("content");
+
+            var url = "/cart";
+            var paramData = {
+                itemId : $("#itemId").val(),
+                count : $("#count").val()
+            };
+
+            var param = JSON.stringify(paramData);
+
+            $.ajax({
+                url : url,
+                type : "POST",
+                contentType : "application/json",
+                data : param,
+                beforeSend : function(xhr){
+                    /* 데이터를 전송하기 전에 헤더에 csrf 값을 설정 */
+                    xhr.setRequestHeader(header, token);
+                },
+                dataType : "json",
+                cache : false,
+                success : function(result, status){
+                    alert("상품을 장바구니에 담았습니다.");
+                    location.href='/';
+                },
+                error : function(jqXHR, status, error){
+                    if(jqXHR.status == '401'){
+                        alert('로그인 후 이용해주세요');
+                        location.href='/members/login';
+                    } else {
+                        alert(jqXHR.responseText);
+                    }
+                }
+            });
+        }
     </script>
 </th:block>
 
@@ -129,7 +167,7 @@
                 <h3 name="totalPrice" id="totalPrice" class="font-weight-bold"></h3>
             </div>
             <div th:if="${item.itemSellStatus == T(com.catveloper365.studyshop.constant.ItemSellStatus).SELL}" class="text-end">
-                <button type="button" class="btn btn-light btn-outline-primary btn-lg">장바구니 담기</button>
+                <button type="button" class="btn btn-light btn-outline-primary btn-lg" onclick="addCart()">장바구니 담기</button>
                 <button type="button" class="btn btn-primary btn-lg" onclick="order()">주문하기</button>
             </div>
             <div th:unless="${item.itemSellStatus == T(com.catveloper365.studyshop.constant.ItemSellStatus).SELL}" class="text-end">

--- a/src/test/java/com/catveloper365/studyshop/service/CartServiceTest.java
+++ b/src/test/java/com/catveloper365/studyshop/service/CartServiceTest.java
@@ -1,0 +1,102 @@
+package com.catveloper365.studyshop.service;
+
+import com.catveloper365.studyshop.constant.ItemSellStatus;
+import com.catveloper365.studyshop.dto.CartItemDto;
+import com.catveloper365.studyshop.entity.CartItem;
+import com.catveloper365.studyshop.entity.Item;
+import com.catveloper365.studyshop.entity.Member;
+import com.catveloper365.studyshop.repository.CartItemRepository;
+import com.catveloper365.studyshop.repository.ItemRepository;
+import com.catveloper365.studyshop.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@Transactional
+class CartServiceTest {
+
+    @Autowired
+    ItemRepository itemRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    CartService cartService;
+
+    @Autowired
+    CartItemRepository cartItemRepository;
+
+    Item saveItem() {
+        Item item = new Item();
+        item.setItemNm("테스트 상품");
+        item.setPrice(10000);
+        item.setItemDetail("테스트 상품 상세 설명");
+        item.setItemSellStatus(ItemSellStatus.SELL);
+        item.setStockNumber(100);
+        return itemRepository.save(item);
+    }
+
+    Member saveMember() {
+        Member member = new Member();
+        member.setEmail("test@test.com");
+        return memberRepository.save(member);
+    }
+
+    CartItemDto createCartItemDto(Item item, int count) {
+        CartItemDto cartItemDto = new CartItemDto();
+        cartItemDto.setCount(count);
+        cartItemDto.setItemId(item.getId());
+        return cartItemDto;
+    }
+
+    @Test
+    @DisplayName("최초로 장바구니 담기")
+    void addCart() {
+        //given
+        Item item = saveItem();
+        Member member = saveMember();
+
+        CartItemDto cartItemDto = createCartItemDto(item, 5);
+
+        //when
+        Long cartItemId = cartService.addCart(cartItemDto, member.getEmail());
+
+        //then
+        CartItem findCartItem = cartItemRepository.findById(cartItemId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        assertEquals(item.getId(), findCartItem.getItem().getId());
+        assertEquals(cartItemDto.getCount(), findCartItem.getCount());
+    }
+
+    @Test
+    @DisplayName("중복 상품 장바구니 담기")
+    void addDuplicateItemToCart() {
+        //given
+        Item item = saveItem();
+        Member member = saveMember();
+
+        //최초로 장바구니 담기
+        CartItemDto cartItemDto = createCartItemDto(item, 5);
+        Long cartItemId1 = cartService.addCart(cartItemDto, member.getEmail());
+
+        //when
+        Long cartItemId2 = cartService.addCart(cartItemDto, member.getEmail());
+
+        //then
+        assertEquals(cartItemId1, cartItemId2);
+
+        CartItem findCartItem = cartItemRepository.findById(cartItemId1)
+                .orElseThrow(EntityNotFoundException::new);
+        assertEquals(10, findCartItem.getCount());
+    }
+
+}

--- a/src/test/java/com/catveloper365/studyshop/service/ItemServiceTest.java
+++ b/src/test/java/com/catveloper365/studyshop/service/ItemServiceTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 


### PR DESCRIPTION
### 연관 이슈 관리
Closes: #50 

### 교재와 다르게 실습한 부분
1. 장바구니 담기 기능을 수행하는 CartService 클래스의 addCart() 메서드의 로직을 Optional & 람다식을 활용하도록 변경
    - 자세한 사항은 #50 진행 중 이슈 1번 참고

2. 장바구니 담기 기능을 테스트하기 위한 CartServiceTest 클래스에 테스트 케이스 추가
    - 교재 : 최초로 장바구니에 상품을 담는 경우만 테스트함
    - 나 : 이미 장바구니에 담겨있는 상품을 또 담았을 때, 수량만 증가하는 경우에 대한 테스트 케이스 추가